### PR TITLE
Remove <Authors> from csproj

### DIFF
--- a/Plugins/BTCPayServer.Plugins.AOPP/BTCPayServer.Plugins.AOPP.csproj
+++ b/Plugins/BTCPayServer.Plugins.AOPP/BTCPayServer.Plugins.AOPP.csproj
@@ -10,7 +10,6 @@
     <PropertyGroup>
       <Product>AOPP</Product>
       <Description>Allows you to support the AOPP protocol in invoices to allow customers to bypass stupid KYC rules.</Description>
-      <Authors>Kukks</Authors>
       <Version>1.0.1</Version>
     </PropertyGroup>
 

--- a/Plugins/BTCPayServer.Plugins.BitcoinWhitepaper/BTCPayServer.Plugins.BitcoinWhitepaper.csproj
+++ b/Plugins/BTCPayServer.Plugins.BitcoinWhitepaper/BTCPayServer.Plugins.BitcoinWhitepaper.csproj
@@ -10,7 +10,6 @@
         <PropertyGroup>
             <Product>Bitcoin Whitepaper</Product>
             <Description>This makes the Bitcoin whitepaper available on your BTCPay Server.</Description>
-            <Authors>Kukks</Authors>
             <Version>1.0.2</Version>
         </PropertyGroup>
         <!-- Plugin development properties -->

--- a/Plugins/BTCPayServer.Plugins.FixedFloat/BTCPayServer.Plugins.FixedFloat.csproj
+++ b/Plugins/BTCPayServer.Plugins.FixedFloat/BTCPayServer.Plugins.FixedFloat.csproj
@@ -9,7 +9,6 @@
     <PropertyGroup>
         <Product>FixedFloat</Product>
         <Description>Allows you to embed a FixedFloat conversion screen to allow customers to pay with altcoins.</Description>
-        <Authors>Kukks</Authors>
         <Version>1.0.6</Version>
     </PropertyGroup>
     <!-- Plugin development properties -->

--- a/Plugins/BTCPayServer.Plugins.LSP/BTCPayServer.Plugins.LSP.csproj
+++ b/Plugins/BTCPayServer.Plugins.LSP/BTCPayServer.Plugins.LSP.csproj
@@ -12,7 +12,6 @@
   <PropertyGroup>
     <Product>LSP</Product>
     <Description>Allows you to become an LSP selling lightning channels with inbound liquidity</Description>
-    <Authors>Kukks</Authors>
     <Version>1.0.0</Version>
   </PropertyGroup>
 <!-- Plugin development properties -->

--- a/Plugins/BTCPayServer.Plugins.LiquidPlus/BTCPayServer.Plugins.LiquidPlus.csproj
+++ b/Plugins/BTCPayServer.Plugins.LiquidPlus/BTCPayServer.Plugins.LiquidPlus.csproj
@@ -11,7 +11,6 @@
     <PropertyGroup>
       <Product>Liquid+</Product>
       <Description>Enhanced support for the liquid network.</Description>
-      <Authors>Kukks</Authors>
       <Version>1.0.8</Version>
     </PropertyGroup>
 

--- a/Plugins/BTCPayServer.Plugins.NFC/BTCPayServer.Plugins.NFC.csproj
+++ b/Plugins/BTCPayServer.Plugins.NFC/BTCPayServer.Plugins.NFC.csproj
@@ -11,7 +11,6 @@
     <PropertyGroup>
       <Product>LNURL NFC Support</Product>
       <Description>Allows you to support contactless card payments over NFC and LNURL Withdraw!</Description>
-      <Authors>Kukks</Authors>
       <Version>1.0.8</Version>
     </PropertyGroup>
     <!-- Plugin development properties -->

--- a/Plugins/BTCPayServer.Plugins.SideShift/BTCPayServer.Plugins.SideShift.csproj
+++ b/Plugins/BTCPayServer.Plugins.SideShift/BTCPayServer.Plugins.SideShift.csproj
@@ -9,7 +9,6 @@
   <PropertyGroup>
     <Product>SideShift</Product>
     <Description>Allows you to embed a SideShift conversion screen to allow customers to pay with altcoins.</Description>
-    <Authors>Kukks</Authors>
     <Version>1.0.9</Version>
   </PropertyGroup>
   <!-- Plugin development properties -->

--- a/Plugins/BTCPayServer.Plugins.TicketTailor/BTCPayServer.Plugins.TicketTailor.csproj
+++ b/Plugins/BTCPayServer.Plugins.TicketTailor/BTCPayServer.Plugins.TicketTailor.csproj
@@ -9,7 +9,6 @@
     <PropertyGroup>
         <Product>TicketTailor</Product>
         <Description>Allows you to integrate with TicketTailor.com to sell tickets for Bitcoin</Description>
-        <Authors>Kukks</Authors>
         <Version>1.0.5</Version>
     </PropertyGroup>
     <!-- Plugin development properties -->

--- a/Plugins/BTCPayServer.Plugins.Wabisabi/BTCPayServer.Plugins.Wabisabi.csproj
+++ b/Plugins/BTCPayServer.Plugins.Wabisabi/BTCPayServer.Plugins.Wabisabi.csproj
@@ -9,7 +9,6 @@
     <PropertyGroup>
         <Product>Wabisabi Coinjoin</Product>
         <Description>Allows you to integrate your btcpayserver store with coinjoins.</Description>
-        <Authors>Kukks</Authors>
         <Version>1.0.10</Version>
     </PropertyGroup>
 


### PR DESCRIPTION
This element isn't used, so we shouldn't use it.
The Author displayed in the plugin list is based on the github's repository.