### PR TITLE
docs: add blink plugin readme

### DIFF
--- a/Plugins/BTCPayServer.Plugins.Blink/README.md
+++ b/Plugins/BTCPayServer.Plugins.Blink/README.md
@@ -1,0 +1,5 @@
+# Blink lightning support plugin
+
+Allows to use a [Blink Wallet](https://blink.sv) account as the lightning provider for BTCPay Server.
+
+Find detailed documentation on how to use this plugin at [dev.blink.sv/examples/btcpayserver-plugin](https://dev.blink.sv/examples/btcpayserver-plugin).


### PR DESCRIPTION
Adding a short readme for the Blink plugin pointing to https://dev.blink.sv/examples/btcpayserver-plugin for details.