### PR TITLE
Add 'signet' option to blink possible networks

### DIFF
--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningClient.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningClient.cs
@@ -525,6 +525,7 @@ query GetNetworkAndDefaultWallet {
         {
             "mainnet" => Network.Main,
             "testnet" => Network.TestNet,
+            "signet" => Network.TestNet,
             "regtest" => Network.RegTest,
             _ => throw new ArgumentOutOfRangeException()
         };


### PR DESCRIPTION
`signet` invoices are compatible with `Testnet` parsing here -> https://github.com/btcpayserver/BTCPayServer.Lightning/blob/c447bb8c0addcb4f2ea98806aa2760c720af6ab6/src/BTCPayServer.Lightning.Common/BOLT11PaymentRequest.cs#L55