### PR TITLE
Add note on gl-certs.zip

### DIFF
--- a/Plugins/BTCPayServer.Plugins.Breez/README.md
+++ b/Plugins/BTCPayServer.Plugins.Breez/README.md
@@ -16,7 +16,7 @@ If you have used any other wallet that uses Breez SDK, you can import it directl
 2. In your store > Wallets > Lightning, Configure Breez
 3. You will be on a page asking for:
    - Mnemonic: This is your 12 word seed phrase. YOU SHOULD GENERATE THIS SAFELY AND KEEP IT SAFE. If you have used Breez before, you can use the same seed phrase you used in Breez. This SEED PHRASE will be stored on BTCPAY SERVER.  IF YOU USE A SHARED BTCPAY SERVER, YOU ARE EXPOSING YOUR SEED PHRASE TO THE SERVER ADMINISTRATOR.
-   - Greenlight credentials: In the case of a new seed, you'll need to acquire certificates for issuing new nodes from Blockstream. You can get these for free at https://greenlight.blockstream.com.
+   - Greenlight credentials: In the case of a new seed, you'll need to acquire certificates for issuing new nodes from Blockstream. You can get these for free at https://greenlight.blockstream.com. Select the entire `gl-certs.zip` file provided by Greenlight.
    - Invite Code: Alternatively, you may have an invite code which can be used instead of the Greenlight credentials.
 4. Click Save
 5. Your new lightning node will be created.


### PR DESCRIPTION
I set this up today and got a bit confused adding the Greenlight credentials. I assumed it would need just one of the files, not both, and definitely didn't expect it to need the full zip!

After messing with it for a bit and realizing it required full zip I figured I'd update the readme to make it a bit easier for future users :)