### PR TITLE
Support the documented type=nwc;key= connection string

### DIFF
--- a/Plugins/BTCPayServer.Plugins.NIP05/NostrWalletConnectLightningConnectionStringHandler.cs
+++ b/Plugins/BTCPayServer.Plugins.NIP05/NostrWalletConnectLightningConnectionStringHandler.cs
@@ -27,7 +27,14 @@ public class NostrWalletConnectLightningConnectionStringHandler : ILightningConn
             return null;
         }
 
-        connectionString = connectionString.Replace("type=nwc;key=", "");
+        if (connectionString.StartsWith("type=nwc;key=", StringComparison.OrdinalIgnoreCase))
+        {
+            string scheme = "nostr+walletconnect:";
+            connectionString = connectionString.Replace("type=nwc;key=", "");
+            if (!connectionString.StartsWith(scheme, StringComparison.OrdinalIgnoreCase))
+                connectionString = scheme + connectionString;
+        }
+
         try
         {
             Uri.TryCreate(connectionString, UriKind.Absolute, out var uri);


### PR DESCRIPTION
In the `LNPaymentMethodSetupTab`, you document

```
type=nwc;key=b889ff5b1513b641e2a139f661a661364979c5beee91842f8f0ef42ab558e9d4?relay=wss%3A%2F%2Frelay.damus.io&secret=71a8c14c1407c113601079c4302dab36460f0ccd0ad506f1f2dc73b5100e4f3c
```
However, this format doesn't work, because `nostr+walletconnect://` is missing.