### PR TITLE
Validation of Nostr connection shouldn't be in CreateClient

### DIFF
--- a/Plugins/BTCPayServer.Plugins.NIP05/NostrWalletConnectLightningConnectionStringHandler.cs
+++ b/Plugins/BTCPayServer.Plugins.NIP05/NostrWalletConnectLightningConnectionStringHandler.cs
@@ -39,55 +39,8 @@ public class NostrWalletConnectLightningConnectionStringHandler : ILightningConn
             error = "Invalid nostr wallet connect uri";
             return null;
         }
-        try
-        {
-            var connectParams = NIP47.ParseUri(uri); 
-            var cts = new CancellationTokenSource();
-            cts.CancelAfter(TimeSpan.FromSeconds(10));
-            var (client, disposable) = _nostrClientPool.GetClientAndConnect(connectParams.relays,  cts.Token).ConfigureAwait(false).GetAwaiter().GetResult();
-            using (disposable)
-            {
-                var commands = client.FetchNIP47AvailableCommands(connectParams.Item1, cancellationToken: cts.Token)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
-                var requiredCommands = new[] {"get_info", "make_invoice", "lookup_invoice", "list_transactions"};
-                if (commands?.Commands is null || requiredCommands.Any(c => !commands.Value.Commands.Contains(c)))
-                {
-                    error =
-                        "No commands available or not all required commands are available (get_info, make_invoice, lookup_invoice, list_transactions)";
-                    return null;
-                }
 
-                var response = client
-                    .SendNIP47Request<NIP47.GetInfoResponse>(connectParams.pubkey, connectParams.secret,
-                        new NIP47.GetInfoRequest(), cancellationToken: cts.Token).ConfigureAwait(false).GetAwaiter()
-                    .GetResult();
-
-                var walletNetwork = response.Network;
-                if (!network.ChainName.ToString().Equals(walletNetwork,
-                        StringComparison.InvariantCultureIgnoreCase))
-                {
-                    error =
-                        $"The network of the wallet ({walletNetwork}) does not match the network of the server ({network.ChainName})";
-                    return null;
-                }
-                if (response?.Methods is null || requiredCommands.Any(c => !response.Methods.Contains(c)))
-                {
-                    error =
-                        "No commands available or not all required commands are available (get_info, make_invoice, lookup_invoice, list_transactions)";
-                    return null;
-                }
-
-                (string[] Commands, string[] Notifications) values = (response.Methods ?? commands.Value.Commands,
-                    response.Notifications ?? commands.Value.Notifications);
-
-                error = null;
-                return new NostrWalletConnectLightningClient(_nostrClientPool, uri, network, values);
-            }
-        }
-        catch (Exception e)
-        {
-            error = "Invalid nostr wallet connect uri: " + e.Message;
-            return null;
-        }
-    }
+        error = null;
+		return new NostrWalletConnectLightningClient(_nostrClientPool, uri, network);
+	}
 }


### PR DESCRIPTION
This is the first part of fixing https://github.com/btcpayserver/btcpayserver/issues/6560 and https://github.com/Kukks/BTCPayServerPlugins/issues/83

Call to the network was done in `NostrWalletConnectLightningConnectionStringHandler.Create` for validation purpose.

Problem is that a call to the NNostr library (`GetClientAndConnect`) doesn't respect the cancellation token. So it meant that if a relay stopped working for ANY store in BTCPay, the whole server would crash due to threads being completely blocked one after the other.

This PR remove the network calls from `NostrWalletConnectLightningConnectionStringHandler.Create`, moving it to `Validate` which will only be called in `Test Connection`.

However the bug remains as `Listen` is calling `GetClientAndConnect` which is blocked due to [another bug from the NNostr library](https://github.com/Kukks/NNostr/issues/29). This will not crash all the server, but will provoke a memory exhaustion over time. (May be related to [this other issue](https://github.com/Kukks/NNostr/issues/27))

You can easily reproduce the bug by using the following connection string and clicking on `Test Connection`.

```
nostr+walletconnect://142cc22d6c00258709ae2b5312c54d40420b0aa495839ce5f13ae0025f1263db?relay=wss://relay.getalby.com/v1&secret=e06cffe97a30701d309d8c041ef67e2b37f1524c128ce594501f21cd723350d8
```

