### PR TITLE
[bug] Fixed little typo on Nostr plugin button

### DIFF
--- a/Plugins/BTCPayServer.Plugins.NIP05/Views/Nip5/Edit.cshtml
+++ b/Plugins/BTCPayServer.Plugins.NIP05/Views/Nip5/Edit.cshtml
@@ -15,7 +15,7 @@
         <h2 class="mb-0">@ViewData["Title"]</h2>
         <div class="d-flex gap-3 mt-3 mt-sm-0">
             <button name="command" type="submit" value="save" class="btn btn-primary">Submit</button>
-            <button name="command" type="button" class="btn btn-primary" style="display: none" id="import">Import wth Nostr extension</button>
+            <button name="command" type="button" class="btn btn-primary" style="display: none" id="import">Import with Nostr extension</button>
             @if (!string.IsNullOrEmpty(Model.Name))
             {
                 <button name="command" type="submit" value="remove" class="btn btn-danger">Clear</button>


### PR DESCRIPTION
This PR fixes a little typo on the Nostr plugin button

Replaces "Import `wth` Nostr extension" with "Import with Nostr extension"