### PR TITLE
Tweaking invoice listening logic for disconnections

### DIFF
--- a/Plugins/BTCPayServer.Plugins.Blink/BTCPayServer.Plugins.Blink.csproj
+++ b/Plugins/BTCPayServer.Plugins.Blink/BTCPayServer.Plugins.Blink.csproj
@@ -9,7 +9,7 @@
     <PropertyGroup>
         <Product>Blink</Product>
         <Description>Blink Lightning support</Description>
-        <Version>1.0.10</Version>
+        <Version>1.0.11</Version>
 <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <RootNamespace>BTCPayServer.Plugins.Blink</RootNamespace>
     </PropertyGroup>


### PR DESCRIPTION
Instead of throwing an exception, we return empty LightningInvoice on websocket disconnection, causing a new listening loop to start immediately after.