### PR TITLE
Fix: BlinkLightningClient.GetInvoice should not crash when the invoice is not found

### DIFF
--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningClient.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningClient.cs
@@ -179,9 +179,8 @@ query InvoiceByPaymentHash($paymentHash: PaymentHash!, $walletId: WalletId!) {
             }
         };
         var response = await _client.SendQueryAsync<dynamic>(reques,  cancellation);
-        
-
-        return response.Data is null ? null : ToInvoice(response.Data.me.defaultAccount.walletById.invoiceByPaymentHash);
+        var result = response.Data?.SelectToken("me.defaultAccount.walletById.invoiceByPaymentHash") as JObject;
+        return result is null ? null : ToInvoice(result);
     }
 
     public LightningInvoice? ToInvoice(JObject invoice)


### PR DESCRIPTION
Fix this error:

```
info: PayServer:      BTC (Lightning): Start listening https://api.blink.sv/graphql
fail: PayServer:      BTC (Lightning): Error while contacting https://api.blink.sv/graphql
Microsoft.CSharp.RuntimeBinder.RuntimeBinderException: 'Newtonsoft.Json.Linq.JValue' does not contain a definition for 'defaultAccount'
   at CallSite.Target(Closure, CallSite, Object)
   at BTCPayServer.Plugins.Blink.BlinkLightningClient.GetInvoice(String invoiceId, CancellationToken cancellation) in /root/BTCPayServerPlugins/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningClient.cs:line 202
   at BTCPayServer.Payments.Lightning.LightningInstanceListener.PollPayment(ListenedInvoice listenedInvoice, CancellationToken cancellation) in /source/BTCPayServer/Payments/Lightning/LightningListener.cs:line 493
   at BTCPayServer.Payments.Lightning.LightningInstanceListener.PollAllListenedInvoices(CancellationToken cancellation) in /source/BTCPayServer/Payments/Lightning/LightningListener.cs:line 591
   at BTCPayServer.Payments.Lightning.LightningInstanceListener.Listen(CancellationToken cancellation) in /source/BTCPayServer/Payments/Lightning/LightningListener.cs:line 532
```