### PR TITLE
 bump Nostr NIP05 plugin version

### DIFF
--- a/Plugins/BTCPayServer.Plugins.NIP05/BTCPayServer.Plugins.NIP05.csproj
+++ b/Plugins/BTCPayServer.Plugins.NIP05/BTCPayServer.Plugins.NIP05.csproj
@@ -11,7 +11,7 @@
     <PropertyGroup>
         <Product>Nostr</Product>
         <Description>NIP5 addresses, Zap support, Nostr Wallet Connect Lightning support</Description>
-        <Version>1.1.19</Version>
+        <Version>1.1.20</Version>
 <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
     <!-- Plugin development properties -->


### PR DESCRIPTION
This is a PR to bump the Nostr NIP05 plugin version and to apply this fix https://github.com/Kukks/BTCPayServerPlugins/pull/87