### PR TITLE
feat(stripe): Add Greenfield API for remote panel integration

### DIFF
--- a/Plugins/BTCPayServer.Plugins.Stripe/Controllers/GreenfieldStripeController.cs
+++ b/Plugins/BTCPayServer.Plugins.Stripe/Controllers/GreenfieldStripeController.cs
@@ -1,0 +1,294 @@
+#nullable enable
+using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Constants;
+using BTCPayServer.Abstractions.Extensions;
+using BTCPayServer.Client;
+using BTCPayServer.Data;
+using BTCPayServer.Payments;
+using BTCPayServer.Plugins.Stripe.Models.Api;
+using BTCPayServer.Services.Invoices;
+using BTCPayServer.Plugins.Stripe.PaymentHandler;
+using BTCPayServer.Plugins.Stripe.Services;
+using BTCPayServer.Services.Stores;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Cors;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BTCPayServer.Plugins.Stripe.Controllers;
+
+/// <summary>
+/// Greenfield API controller for managing Stripe settings.
+/// Enables remote control of Stripe configuration via API key authentication.
+/// </summary>
+[ApiController]
+[Authorize(AuthenticationSchemes = AuthenticationSchemes.Greenfield, Policy = Policies.CanViewStoreSettings)]
+[EnableCors(CorsPolicies.All)]
+public class GreenfieldStripeController : ControllerBase
+{
+    private readonly StoreRepository _storeRepository;
+    private readonly PaymentMethodHandlerDictionary _handlers;
+    private readonly StripeService _stripeService;
+
+    public GreenfieldStripeController(
+        StoreRepository storeRepository,
+        PaymentMethodHandlerDictionary handlers,
+        StripeService stripeService)
+    {
+        _storeRepository = storeRepository;
+        _handlers = handlers;
+        _stripeService = stripeService;
+    }
+
+    private static StripePaymentMethodConfig? GetConfig(StoreData store, PaymentMethodHandlerDictionary handlers)
+    {
+        return store.GetPaymentMethodConfig<StripePaymentMethodConfig>(
+            StripePlugin.StripePaymentMethodId, handlers);
+    }
+
+    private static string? MaskApiKey(string? key)
+    {
+        if (string.IsNullOrEmpty(key))
+            return null;
+        if (key.Length <= 10)
+            return "***";
+        return key[..3] + "***..." + key[^4..];
+    }
+
+    private static StripeSettingsData ToStripeSettingsData(StripePaymentMethodConfig config)
+    {
+        return new StripeSettingsData
+        {
+            Enabled = config.Enabled,
+            PublishableKey = MaskApiKey(config.PublishableKey),
+            SecretKey = MaskApiKey(config.SecretKey),
+            SettlementCurrency = config.SettlementCurrency ?? "USD",
+            AdvancedConfig = config.AdvancedConfig,
+            IsConfigured = config.IsConfigured,
+            IsTestMode = config.IsTestMode,
+            WebhookId = config.WebhookId
+        };
+    }
+
+    /// <summary>
+    /// Get Stripe settings for a store.
+    /// </summary>
+    [HttpGet("~/api/v1/stores/{storeId}/stripe/settings")]
+    public async Task<IActionResult> GetSettings(string storeId)
+    {
+        var store = HttpContext.GetStoreData();
+        if (store == null)
+            return StoreNotFound();
+
+        var config = GetConfig(store, _handlers) ?? new StripePaymentMethodConfig();
+        return Ok(ToStripeSettingsData(config));
+    }
+
+    /// <summary>
+    /// Update Stripe settings for a store.
+    /// </summary>
+    [HttpPut("~/api/v1/stores/{storeId}/stripe/settings")]
+    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+    public async Task<IActionResult> UpdateSettings(string storeId, [FromBody] UpdateStripeSettingsRequest? request)
+    {
+        var store = HttpContext.GetStoreData();
+        if (store == null)
+            return StoreNotFound();
+
+        if (request == null)
+        {
+            ModelState.AddModelError(string.Empty, "Request body is required");
+            return this.CreateValidationError(ModelState);
+        }
+
+        var existingConfig = GetConfig(store, _handlers) ?? new StripePaymentMethodConfig();
+        var config = new StripePaymentMethodConfig
+        {
+            Enabled = request.Enabled ?? existingConfig.Enabled,
+            PublishableKey = !string.IsNullOrWhiteSpace(request.PublishableKey)
+                ? request.PublishableKey.Trim()
+                : existingConfig.PublishableKey,
+            SecretKey = !string.IsNullOrWhiteSpace(request.SecretKey)
+                ? request.SecretKey.Trim()
+                : existingConfig.SecretKey,
+            SettlementCurrency = !string.IsNullOrWhiteSpace(request.SettlementCurrency)
+                ? request.SettlementCurrency.Trim().ToUpperInvariant()
+                : (existingConfig.SettlementCurrency ?? "USD"),
+            AdvancedConfig = request.AdvancedConfig ?? existingConfig.AdvancedConfig,
+            WebhookId = existingConfig.WebhookId,
+            WebhookSecret = existingConfig.WebhookSecret
+        };
+
+        if (config.Enabled)
+        {
+            if (string.IsNullOrWhiteSpace(config.PublishableKey))
+                ModelState.AddModelError(nameof(request.PublishableKey), "Publishable key is required when enabled");
+            if (string.IsNullOrWhiteSpace(config.SecretKey))
+                ModelState.AddModelError(nameof(request.SecretKey), "Secret key is required when enabled");
+            if (string.IsNullOrWhiteSpace(config.SettlementCurrency))
+                ModelState.AddModelError(nameof(request.SettlementCurrency), "Settlement currency is required");
+            if (!string.IsNullOrWhiteSpace(config.PublishableKey) && !config.PublishableKey.StartsWith("pk_"))
+                ModelState.AddModelError(nameof(request.PublishableKey), "Publishable key must start with 'pk_'");
+            if (!string.IsNullOrWhiteSpace(config.SecretKey) && !config.SecretKey.StartsWith("sk_"))
+                ModelState.AddModelError(nameof(request.SecretKey), "Secret key must start with 'sk_'");
+        }
+
+        if (!ModelState.IsValid)
+            return this.CreateValidationError(ModelState);
+
+        var handler = _handlers[StripePlugin.StripePaymentMethodId];
+        store.SetPaymentMethodConfig(handler, config);
+        await _storeRepository.UpdateStore(store);
+
+        return Ok(ToStripeSettingsData(config));
+    }
+
+    /// <summary>
+    /// Clear Stripe credentials for a store.
+    /// </summary>
+    [HttpDelete("~/api/v1/stores/{storeId}/stripe/settings")]
+    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+    public async Task<IActionResult> DeleteSettings(string storeId)
+    {
+        var store = HttpContext.GetStoreData();
+        if (store == null)
+            return StoreNotFound();
+
+        var existingConfig = GetConfig(store, _handlers);
+        if (existingConfig == null)
+            return Ok();
+
+        if (!string.IsNullOrEmpty(existingConfig.WebhookId) && !string.IsNullOrEmpty(existingConfig.SecretKey))
+        {
+            try
+            {
+                await _stripeService.DeleteWebhook(existingConfig);
+            }
+            catch
+            {
+                // Ignore - webhook may already be deleted
+            }
+        }
+
+        var config = new StripePaymentMethodConfig
+        {
+            Enabled = false,
+            SettlementCurrency = existingConfig.SettlementCurrency ?? "USD",
+            AdvancedConfig = existingConfig.AdvancedConfig
+        };
+
+        var handler = _handlers[StripePlugin.StripePaymentMethodId];
+        store.SetPaymentMethodConfig(handler, config);
+        await _storeRepository.UpdateStore(store);
+
+        return Ok();
+    }
+
+    /// <summary>
+    /// Test connection to Stripe API.
+    /// </summary>
+    [HttpPost("~/api/v1/stores/{storeId}/stripe/test")]
+    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+    public async Task<IActionResult> TestConnection(string storeId)
+    {
+        var store = HttpContext.GetStoreData();
+        if (store == null)
+            return StoreNotFound();
+
+        var config = GetConfig(store, _handlers);
+        if (config == null || !config.IsConfigured)
+        {
+            return this.CreateAPIError(422, "stripe-not-configured",
+                "Stripe is not configured for this store. Configure API keys first.");
+        }
+
+        var (success, error) = await _stripeService.TestConnection(config);
+
+        return Ok(new TestConnectionResponse
+        {
+            Success = success,
+            Message = success
+                ? $"Successfully connected to Stripe ({(config.IsTestMode ? "Test Mode" : "Live Mode")})"
+                : $"Failed to connect to Stripe: {error}",
+            Mode = config.IsTestMode ? "test" : "live"
+        });
+    }
+
+    /// <summary>
+    /// Register webhook endpoint with Stripe.
+    /// </summary>
+    [HttpPost("~/api/v1/stores/{storeId}/stripe/webhook/register")]
+    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+    public async Task<IActionResult> RegisterWebhook(string storeId)
+    {
+        var store = HttpContext.GetStoreData();
+        if (store == null)
+            return StoreNotFound();
+
+        var config = GetConfig(store, _handlers);
+        if (config == null || !config.IsConfigured)
+        {
+            return this.CreateAPIError(422, "stripe-not-configured",
+                "Stripe is not configured for this store. Configure API keys first.");
+        }
+
+        var externalUrl = Request.GetAbsoluteRoot();
+        var result = await _stripeService.TryRegisterWebhook(config, storeId, externalUrl);
+
+        if (result.Success)
+        {
+            config.WebhookId = result.WebhookId;
+            if (!string.IsNullOrEmpty(result.WebhookSecret))
+                config.WebhookSecret = result.WebhookSecret;
+
+            var handler = _handlers[StripePlugin.StripePaymentMethodId];
+            store.SetPaymentMethodConfig(handler, config);
+            await _storeRepository.UpdateStore(store);
+        }
+
+        if (result.Success)
+        {
+            return Ok(new { success = true, message = result.Message });
+        }
+
+        return this.CreateAPIError(422, "webhook-registration-failed", result.Reason ?? "Failed to register webhook");
+    }
+
+    /// <summary>
+    /// Get webhook status for a store.
+    /// </summary>
+    [HttpGet("~/api/v1/stores/{storeId}/stripe/webhook/status")]
+    public async Task<IActionResult> GetWebhookStatus(string storeId)
+    {
+        var store = HttpContext.GetStoreData();
+        if (store == null)
+            return StoreNotFound();
+
+        var config = GetConfig(store, _handlers);
+        if (config == null || !config.IsConfigured)
+        {
+            return Ok(new WebhookStatusData
+            {
+                Configured = false,
+                Message = "Stripe is not configured"
+            });
+        }
+
+        var externalUrl = Request.GetAbsoluteRoot();
+        var status = await _stripeService.GetWebhookStatus(config, storeId, externalUrl);
+
+        return Ok(new WebhookStatusData
+        {
+            Configured = status.IsConfigured,
+            WebhookId = status.WebhookId,
+            WebhookUrl = status.WebhookUrl,
+            Message = status.IsValid
+                ? "Webhook is active"
+                : (status.Error ?? status.Status ?? "Not configured")
+        });
+    }
+
+    private IActionResult StoreNotFound()
+    {
+        return this.CreateAPIError(404, "store-not-found", "The store was not found");
+    }
+}

--- a/Plugins/BTCPayServer.Plugins.Stripe/Models/Api/StripeSettingsData.cs
+++ b/Plugins/BTCPayServer.Plugins.Stripe/Models/Api/StripeSettingsData.cs
@@ -1,0 +1,34 @@
+#nullable enable
+namespace BTCPayServer.Plugins.Stripe.Models.Api;
+
+/// <summary>
+/// Stripe settings data returned by the Greenfield API.
+/// API keys are masked for security.
+/// </summary>
+public class StripeSettingsData
+{
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Masked publishable key (e.g. pk_***...xyz)
+    /// </summary>
+    public string? PublishableKey { get; set; }
+
+    /// <summary>
+    /// Masked secret key (e.g. sk_***...xyz)
+    /// </summary>
+    public string? SecretKey { get; set; }
+
+    public string SettlementCurrency { get; set; } = "USD";
+
+    public string? AdvancedConfig { get; set; }
+
+    public bool IsConfigured { get; set; }
+
+    public bool IsTestMode { get; set; }
+
+    /// <summary>
+    /// Stripe webhook endpoint ID if configured
+    /// </summary>
+    public string? WebhookId { get; set; }
+}

--- a/Plugins/BTCPayServer.Plugins.Stripe/Models/Api/TestConnectionResponse.cs
+++ b/Plugins/BTCPayServer.Plugins.Stripe/Models/Api/TestConnectionResponse.cs
@@ -1,0 +1,17 @@
+#nullable enable
+namespace BTCPayServer.Plugins.Stripe.Models.Api;
+
+/// <summary>
+/// Response from the test connection endpoint.
+/// </summary>
+public class TestConnectionResponse
+{
+    public bool Success { get; set; }
+
+    public string? Message { get; set; }
+
+    /// <summary>
+    /// "test" or "live" depending on API key mode
+    /// </summary>
+    public string? Mode { get; set; }
+}

--- a/Plugins/BTCPayServer.Plugins.Stripe/Models/Api/UpdateStripeSettingsRequest.cs
+++ b/Plugins/BTCPayServer.Plugins.Stripe/Models/Api/UpdateStripeSettingsRequest.cs
@@ -1,0 +1,19 @@
+#nullable enable
+namespace BTCPayServer.Plugins.Stripe.Models.Api;
+
+/// <summary>
+/// Request to update Stripe settings.
+/// All fields are optional - existing values are preserved when not provided.
+/// </summary>
+public class UpdateStripeSettingsRequest
+{
+    public bool? Enabled { get; set; }
+
+    public string? PublishableKey { get; set; }
+
+    public string? SecretKey { get; set; }
+
+    public string? SettlementCurrency { get; set; }
+
+    public string? AdvancedConfig { get; set; }
+}

--- a/Plugins/BTCPayServer.Plugins.Stripe/Models/Api/WebhookStatusData.cs
+++ b/Plugins/BTCPayServer.Plugins.Stripe/Models/Api/WebhookStatusData.cs
@@ -1,0 +1,16 @@
+#nullable enable
+namespace BTCPayServer.Plugins.Stripe.Models.Api;
+
+/// <summary>
+/// Webhook status data returned by the Greenfield API.
+/// </summary>
+public class WebhookStatusData
+{
+    public bool Configured { get; set; }
+
+    public string? WebhookId { get; set; }
+
+    public string? WebhookUrl { get; set; }
+
+    public string? Message { get; set; }
+}


### PR DESCRIPTION
- Add GreenfieldStripeController with settings, test, webhook endpoints
- Add API DTO models (StripeSettingsData, UpdateStripeSettingsRequest, etc.)
- Support GET/PUT/DELETE settings, POST test, POST webhook/register, GET webhook/status
- Enables remote control of Stripe config via API key

> **Note:** I'm not a C# developer — this was vibecoded with AI assistance. The API has been deployed and tested in production on [satflux.io](https://satflux.io).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Greenfield API endpoints for managing Stripe payment settings per store
  * New endpoints to retrieve, update, and delete Stripe configuration
  * Added API endpoint to test Stripe connectivity
  * Added endpoints for registering and checking Stripe webhook status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->