### PR TITLE
Remove obsolete link

### DIFF
--- a/Plugins/BTCPayServer.Plugins.Wabisabi/readme.md
+++ b/Plugins/BTCPayServer.Plugins.Wabisabi/readme.md
@@ -1,6 +1,6 @@
 # The BTCPay Server Coinjoin plugin
 
-This plugin allows every BTCPay Server instance to integrate with the Wabisabi coinjoin protocol developed by [zkSNACKS](https://zksnacks.com/) ([Wasabi Wallet](https://wasabiwallet.io/)).
+This plugin allows every BTCPay Server instance to integrate with the Wabisabi coinjoin protocol developed by zkSNACKS ([Wasabi Wallet](https://wasabiwallet.io/)).
 
 
 <p align="center">


### PR DESCRIPTION
The zkSNACKs organization shut down & its domain expired.

The document as a whole should probably be archived since the plugin has been discontinued.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated attribution text and hyperlink structure for the Wabisabi coinjoin protocol documentation to clarify the reference source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->