### PR TITLE
.net8.0 -> .net10.0

### DIFF
--- a/ConfigBuilder/Program.cs
+++ b/ConfigBuilder/Program.cs
@@ -9,14 +9,16 @@ foreach (var plugin in plugins)
     {
         var assemblyConfigurationAttribute = typeof(Program).Assembly.GetCustomAttribute<AssemblyConfigurationAttribute>();
         var buildConfigurationName = assemblyConfigurationAttribute?.Configuration;
-        var x = Directory.GetDirectories(Path.Combine(plugin, "bin"));
+        
+        var binPath = Path.Combine(plugin, "bin");
+        if (!Directory.Exists(binPath)) continue;
 
-        var f = $"{Path.GetFullPath(plugin)}/bin/{buildConfigurationName}/net8.0/{Path.GetFileName(plugin)}.dll";
+        var f = $"{Path.GetFullPath(plugin)}/bin/{buildConfigurationName}/net10.0/{Path.GetFileName(plugin)}.dll";
         if (File.Exists(f))
             p += $"{f};";
         else
         {
-            f = $"{Path.GetFullPath(plugin)}/bin/Debug/net8.0/{Path.GetFileName(plugin)}.dll";
+            f = $"{Path.GetFullPath(plugin)}/bin/Debug/net10.0/{Path.GetFileName(plugin)}.dll";
             if (File.Exists(f))
                 p += $"{f};";
         }


### PR DESCRIPTION
Bump .net version in searched path to .net10, since every plugin was migrated to new version. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin discovery robustness by handling missing plugin directories gracefully.

* **Chores**
  * Updated framework target version compatibility for plugin discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->