### PR TITLE
fix(electrum): republish NewOnChainTransactionEvent on every wallet tx

### DIFF
--- a/Plugins/BTCPayServer.Plugins.Electrum/Electrum/ElectrumWalletTracker.cs
+++ b/Plugins/BTCPayServer.Plugins.Electrum/Electrum/ElectrumWalletTracker.cs
@@ -1125,6 +1125,14 @@ public class ElectrumWalletTracker
         public int Confirmations { get; set; }
         public bool IsRbf { get; set; }
         public DateTimeOffset SeenAt { get; set; }
+        /// <summary>
+        /// The raw transaction. Carried through so the listener can republish
+        /// it on the BTCPay <c>NewOnChainTransactionEvent</c> bus — third-party
+        /// plugins that subscribe to that event (e.g. boarding-address /
+        /// payout-monitoring flows) need access to the inputs and outputs,
+        /// not just the txid.
+        /// </summary>
+        public Transaction Transaction { get; set; }
         public List<OutputInfo> Outputs { get; set; } = new();
     }
 
@@ -1148,7 +1156,8 @@ public class ElectrumWalletTracker
             Confirmations = historyItem.Height > 0 && _tipHeight > 0
                 ? _tipHeight - historyItem.Height + 1 : 0,
             IsRbf = tx.RBF,
-            SeenAt = DateTimeOffset.UtcNow
+            SeenAt = DateTimeOffset.UtcNow,
+            Transaction = tx
         };
 
         // Find outputs that match our tracked addresses

--- a/Plugins/BTCPayServer.Plugins.Electrum/Services/ElectrumListener.cs
+++ b/Plugins/BTCPayServer.Plugins.Electrum/Services/ElectrumListener.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using NBXplorer.DerivationStrategy;
+using NBXplorer.Models;
 
 namespace BTCPayServer.Plugins.Electrum.Services;
 
@@ -236,6 +237,47 @@ public class ElectrumListener : IHostedService
                 });
             }
         }
+
+        // Republish the NBXplorer-shaped NewOnChainTransactionEvent so any
+        // plugin that subscribes to it (boarding-address watchers, custom
+        // payout monitors, OnChainRateTrackerHostedService, etc.) keeps
+        // working when Electrum is the explorer backend. Without this, the
+        // NBXplorerListener removal in ElectrumPlugin.Execute leaves those
+        // subscribers silent — addresses receive tx's that the plugin never
+        // sees. Mirrors what NBXplorerListener publishes on every wallet-
+        // touching wire event.
+        if (txInfo.Transaction is null)
+            return;
+
+        var nbxEvent = new NewTransactionEvent
+        {
+            CryptoCode = network.CryptoCode,
+            DerivationStrategy = txInfo.DerivationStrategy,
+            TrackedSource = new DerivationSchemeTrackedSource(txInfo.DerivationStrategy),
+            TransactionData = new TransactionResult
+            {
+                Transaction = txInfo.Transaction,
+                TransactionHash = txInfo.Transaction.GetHash(),
+                Confirmations = txInfo.Confirmations,
+                Timestamp = txInfo.SeenAt,
+            },
+            // BlockId left null: Electrum's per-tx notification stream
+            // doesn't include the containing block hash. Consumers that
+            // care about "confirmed yet" should check Confirmations > 0.
+            Outputs = txInfo.Outputs.Select(o => new MatchedOutput
+            {
+                Index = o.Index,
+                Value = o.Value,
+                KeyPath = string.IsNullOrEmpty(o.KeyPath) ? null : new KeyPath(o.KeyPath),
+                KeyIndex = o.KeyIndex,
+                ScriptPubKey = txInfo.Transaction.Outputs[o.Index].ScriptPubKey,
+            }).ToList(),
+        };
+        _eventAggregator.Publish(new NewOnChainTransactionEvent
+        {
+            PaymentMethodId = pmi,
+            NewTransactionEvent = nbxEvent,
+        });
     }
 
     private async Task FindPaymentsViaPolling(CancellationToken ct)


### PR DESCRIPTION
## Electrum: republish `NewOnChainTransactionEvent` on every wallet tx

### Why
`ElectrumPlugin.Execute(IServiceCollection)` removes `NBXplorerListener` (the original publisher of `NewOnChainTransactionEvent`) and registers `ElectrumListener` in its place. `ElectrumListener` currently publishes `InvoiceEvent`, `NewBlockEvent`, and `InvoiceNeedUpdateEvent` — but **not** `NewOnChainTransactionEvent`.

Side effect: any plugin or BTCPay subsystem that subscribes to `NewOnChainTransactionEvent` goes silent when Electrum is the backend. In BTCPay core that's `OnChainRateTrackerHostedService`, `PendingTransactionService`, and `BitcoinLikePayoutHandler`'s on-chain payout detection. In third-party plugins it's e.g. boarding-address watchers — for example the Arkade plugin's `BoardingTransactionListener.cs:34` subscribes to `NewOnChainTransactionEvent` and never receives one with Electrum installed, so inbound on-chain payments to boarding addresses are silently undetected.

### Change
1. `ElectrumWalletTracker.NewTransactionInfo` carries the raw `NBitcoin.Transaction` through (so the listener can hand it to subscribers).
2. `ElectrumListener.ProcessNewTransaction` constructs an `NBXplorer.Models.NewTransactionEvent` from the data it already gathers (raw `Transaction`, derivation strategy, matched outputs, confirmations) and publishes a `NewOnChainTransactionEvent` once per tx — mirroring what `NBXplorerListener` does.

Populated fields on `NewTransactionEvent`:
- `CryptoCode`, `DerivationStrategy`, `TrackedSource` (as `DerivationSchemeTrackedSource(strategy)`)
- `TransactionData` with `Transaction` / `TransactionHash` / `Confirmations` / `Timestamp`
- `Outputs` as `MatchedOutput`s with `Index`, `Value`, `KeyPath`, `KeyIndex`, `ScriptPubKey`

`BlockId` is left null — Electrum's per-tx notification stream doesn't include the containing block hash. Consumers that care about "confirmed yet" should check `Confirmations > 0`, which is the standard pattern.

### Test plan
- [x] `dotnet build BTCPayServer.Plugins.Electrum.csproj` clean (0 errors).
- [x] No behaviour change for existing consumers — only an additional event is published.
- [ ] Smoke-test side-effect with a subscriber: e.g. install alongside the BTCPay Arkade plugin and confirm boarding-address transactions are detected end-to-end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced transaction event handling in the Electrum wallet integration with complete transaction data, enabling improved tracking and access to detailed input/output information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kukks/BTCPayServerPlugins/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->