### PR TITLE
Conference: fix Edit modal, batch health checks, and UX cleanup

### DIFF
--- a/Plugins/BTCPayServer.Plugins.Conference/BTCPayServer.Plugins.Conference.csproj
+++ b/Plugins/BTCPayServer.Plugins.Conference/BTCPayServer.Plugins.Conference.csproj
@@ -9,7 +9,7 @@
     <PropertyGroup>
         <Product>Conference</Product>
         <Description>Manage conference merchant stores, POS terminals, and sales reporting from a single app</Description>
-        <Version>1.1.0</Version>
+        <Version>1.2.0</Version>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
     <!-- Plugin development properties -->

--- a/Plugins/BTCPayServer.Plugins.Conference/ConferenceController.cs
+++ b/Plugins/BTCPayServer.Plugins.Conference/ConferenceController.cs
@@ -464,9 +464,11 @@ public class ConferenceController : Controller
                 settings.Merchants, timeRange, HttpContext.RequestAborted);
         }
 
+        var healthByEmail = await _provisioningService.CheckMerchantHealthBatch(settings.Merchants);
+
         foreach (var merchant in settings.Merchants)
         {
-            var health = await _provisioningService.CheckMerchantHealth(merchant);
+            var health = healthByEmail[merchant.Email];
             var mvm = new MerchantViewModel
             {
                 Email = merchant.Email,

--- a/Plugins/BTCPayServer.Plugins.Conference/ConferenceProvisioningService.cs
+++ b/Plugins/BTCPayServer.Plugins.Conference/ConferenceProvisioningService.cs
@@ -10,6 +10,7 @@ using BTCPayServer.Plugins.PointOfSale;
 using BTCPayServer.Services.Apps;
 using BTCPayServer.Services.Stores;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 
@@ -119,6 +120,67 @@ public class ConferenceProvisioningService
         {
             status.PosStatus = "Not provisioned";
         }
+
+        return status;
+    }
+
+    // Batched equivalent of CheckMerchantHealth for the settings page: three queries total
+    // (users, stores, POS apps) instead of three per merchant, which made the page O(N)
+    // round-trips as the roster grew. A component is "OK" when its row still exists
+    // (archived included), matching the single-merchant check.
+    public async Task<Dictionary<string, MerchantHealthStatus>> CheckMerchantHealthBatch(
+        IReadOnlyCollection<ConferenceMerchant> merchants)
+    {
+        var userIds = merchants.Where(m => !string.IsNullOrEmpty(m.UserId)).Select(m => m.UserId).Distinct().ToList();
+        var storeIds = merchants.Where(m => !string.IsNullOrEmpty(m.StoreId)).Select(m => m.StoreId).Distinct().ToArray();
+        var appIds = merchants.Where(m => !string.IsNullOrEmpty(m.PosAppId)).Select(m => m.PosAppId).Distinct().ToArray();
+
+        var existingUserIds = new HashSet<string>();
+        if (userIds.Count > 0)
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+            existingUserIds = (await userManager.Users
+                .Where(u => userIds.Contains(u.Id))
+                .Select(u => u.Id)
+                .ToListAsync()).ToHashSet();
+        }
+
+        var existingStoreIds = storeIds.Length == 0
+            ? new HashSet<string>()
+            : (await _storeRepository.GetStores(storeIds)).Select(s => s.Id).ToHashSet();
+
+        var existingAppIds = appIds.Length == 0
+            ? new HashSet<string>()
+            : (await _appService.GetApps(appIds, includeArchived: true)).Select(a => a.Id).ToHashSet();
+
+        var result = new Dictionary<string, MerchantHealthStatus>();
+        foreach (var merchant in merchants)
+            result[merchant.Email] = BuildHealth(merchant, existingUserIds, existingStoreIds, existingAppIds);
+        return result;
+    }
+
+    private static MerchantHealthStatus BuildHealth(
+        ConferenceMerchant merchant,
+        HashSet<string> existingUserIds,
+        HashSet<string> existingStoreIds,
+        HashSet<string> existingAppIds)
+    {
+        var status = new MerchantHealthStatus();
+
+        if (string.IsNullOrEmpty(merchant.UserId))
+        {
+            status.UserStatus = "Not provisioned";
+            return status;
+        }
+
+        status.UserStatus = existingUserIds.Contains(merchant.UserId) ? "OK" : "User deleted";
+        status.StoreStatus = string.IsNullOrEmpty(merchant.StoreId)
+            ? "Not provisioned"
+            : existingStoreIds.Contains(merchant.StoreId) ? "OK" : "Store deleted";
+        status.PosStatus = string.IsNullOrEmpty(merchant.PosAppId)
+            ? "Not provisioned"
+            : existingAppIds.Contains(merchant.PosAppId) ? "OK" : "POS deleted";
 
         return status;
     }

--- a/Plugins/BTCPayServer.Plugins.Conference/ConferenceReportService.cs
+++ b/Plugins/BTCPayServer.Plugins.Conference/ConferenceReportService.cs
@@ -103,6 +103,12 @@ public class ConferenceReportService
             }
 
             report.TotalInvoices += mr.InvoiceCount;
+
+            foreach (var payment in mr.PaymentBreakdown.Values)
+            {
+                report.TotalsReceivedByCurrency.TryGetValue(payment.Currency, out var existingReceived);
+                report.TotalsReceivedByCurrency[payment.Currency] = existingReceived + payment.TotalAmount;
+            }
         }
 
         return report;
@@ -137,6 +143,7 @@ public class ConferenceReport
     public DateTimeOffset EndDate { get; set; }
     public List<MerchantReport> MerchantReports { get; set; } = new();
     public Dictionary<string, decimal> TotalsByStoreCurrency { get; set; } = new();
+    public Dictionary<string, decimal> TotalsReceivedByCurrency { get; set; } = new();
     public int TotalInvoices { get; set; }
 }
 

--- a/Plugins/BTCPayServer.Plugins.Conference/README.md
+++ b/Plugins/BTCPayServer.Plugins.Conference/README.md
@@ -1,0 +1,57 @@
+# Conference
+
+Run many merchant stalls for a conference or event from a single place. The Conference app
+turns a roster of merchants into fully working BTCPay setups and rolls all of their sales up
+into one report.
+
+## What it does
+
+For each merchant (a name + email) the app provisions, in one step:
+
+- a **user** account (or links an existing one),
+- a **store** seeded with your default currency, spread and Lightning connection,
+- a **Point of Sale** app,
+
+and adds the merchant to their own store as an *Employee*. You then hand each merchant a
+one-tap **login code** or their **POS QR**, and watch every stall's takings under **Reports**.
+
+## Setup
+
+1. Add the **Conference** app to your store (store nav → *Conference*).
+2. **Settings tab** — set the defaults every merchant store inherits:
+   - *Default Lightning Connection String* (use `Internal Node` for the server's node),
+   - *Default Currency*,
+   - *Default Spread %*.
+3. **Merchants tab** — add merchants:
+   - inline with **+ Add Row** (email + store name required; currency / spread / password optional), then **Add**, or
+   - in bulk with **Import CSV** (download the **Template** first).
+4. **Provision** each merchant, or **Provision All**, to create their user, store and POS.
+5. Hand out access:
+   - **Login** — a 60-second login-code QR that signs the merchant in and lands them on their POS,
+   - **POS** — a link or QR straight to their Point of Sale.
+
+## Per-merchant overrides
+
+Currency, spread and Lightning connection can be set per merchant; leave a field blank to
+inherit the conference default. **Re-apply Settings to All Stores** (Settings tab) pushes the
+current defaults out to every provisioned store — tick a "force" box to overwrite per-merchant
+values too.
+
+## Health & repair
+
+The Merchants tab shows each merchant's status. If a user, store or POS is deleted out from
+under the app, the row turns red and a **Repair** action recreates only the missing pieces.
+
+## Reports
+
+Once merchants are provisioned, the **Reports** tab aggregates invoices, **Sales** (totalled in
+each store's currency) and **Received** amounts (per payment currency) across all merchant
+stores, for *Today* / *Yesterday* / *Last 7 days*.
+
+## Security notes
+
+- **Login codes are only issued for accounts this app created.** Adding a merchant whose email
+  matches a pre-existing user links that user but never generates a login code for them — this
+  prevents targeting an existing account (e.g. a server admin) through its email address.
+- **Removing a merchant archives** their store and POS rather than deleting them, and **deleting
+  the Conference app leaves every merchant store intact.**

--- a/Plugins/BTCPayServer.Plugins.Conference/Views/Conference/UpdateConferenceSettings.cshtml
+++ b/Plugins/BTCPayServer.Plugins.Conference/Views/Conference/UpdateConferenceSettings.cshtml
@@ -20,12 +20,27 @@
 
 <partial name="_StatusMessage" />
 
+<p class="text-secondary mb-4" style="max-width: 60rem;">
+    Give each merchant in your conference their own store, Point of Sale and login. Add merchants
+    (individually or via CSV), then <strong>Provision</strong> to create their user, store and POS in one
+    step, and hand out a login code or POS QR. Track everyone's combined sales under <strong>Reports</strong>.
+</p>
+
+@{
+    // The Reports tab/pane only exist when a merchant is provisioned, so gate reportsActive
+    // on that and let Settings be the catch-all — otherwise ?tab=reports with no provisioned
+    // merchant activates a pane that was never rendered, leaving a blank page.
+    var hasReports = Model.Merchants.Any(m => m.IsProvisioned);
+    var merchantsActive = activeTab == "merchants";
+    var reportsActive = activeTab == "reports" && hasReports;
+    var settingsActive = !merchantsActive && !reportsActive;
+}
 <ul class="nav nav-tabs mb-4" role="tablist">
     <li class="nav-item" role="presentation">
-        <button class="nav-link @(activeTab is not ("merchants" or "reports") ? "active" : "")" data-bs-toggle="tab" data-bs-target="#settings-tab" type="button" role="tab">Settings</button>
+        <button id="settings-tabBtn" class="nav-link @(settingsActive ? "active" : "")" data-bs-toggle="tab" data-bs-target="#settings-tab" type="button" role="tab" aria-controls="settings-tab" aria-selected="@(settingsActive ? "true" : "false")">Settings</button>
     </li>
     <li class="nav-item" role="presentation">
-        <button class="nav-link @(activeTab == "merchants" ? "active" : "")" data-bs-toggle="tab" data-bs-target="#merchants-tab" type="button" role="tab">
+        <button id="merchants-tabBtn" class="nav-link @(merchantsActive ? "active" : "")" data-bs-toggle="tab" data-bs-target="#merchants-tab" type="button" role="tab" aria-controls="merchants-tab" aria-selected="@(merchantsActive ? "true" : "false")">
             Merchants
             @if (Model.Merchants.Count > 0)
             {
@@ -33,17 +48,17 @@
             }
         </button>
     </li>
-    @if (Model.Merchants.Any(m => m.IsProvisioned))
+    @if (hasReports)
     {
         <li class="nav-item" role="presentation">
-            <button class="nav-link @(activeTab == "reports" ? "active" : "")" data-bs-toggle="tab" data-bs-target="#reports-tab" type="button" role="tab">Reports</button>
+            <button id="reports-tabBtn" class="nav-link @(reportsActive ? "active" : "")" data-bs-toggle="tab" data-bs-target="#reports-tab" type="button" role="tab" aria-controls="reports-tab" aria-selected="@(reportsActive ? "true" : "false")">Reports</button>
         </li>
     }
 </ul>
 
 <div class="tab-content">
     <!-- Settings Tab -->
-    <div class="tab-pane fade @(activeTab is not ("merchants" or "reports") ? "show active" : "")" id="settings-tab" role="tabpanel">
+    <div class="tab-pane fade @(settingsActive ? "show active" : "")" id="settings-tab" role="tabpanel" aria-labelledby="settings-tabBtn">
         <form method="post" asp-action="UpdateSettings" asp-route-appId="@appId">
             <div class="row">
                 <div class="col-xl-8 col-xxl-constrain">
@@ -66,7 +81,7 @@
             </div>
         </form>
 
-        @if (Model.Merchants.Any(m => m.IsProvisioned))
+        @if (hasReports)
         {
             <hr class="my-4" />
             <h4>Re-apply Settings to All Stores</h4>
@@ -94,13 +109,23 @@
     </div>
 
     <!-- Merchants Tab -->
-    <div class="tab-pane fade @(activeTab == "merchants" ? "show active" : "")" id="merchants-tab" role="tabpanel">
-        @if (Model.Merchants.Any(m => !m.IsProvisioned))
+    <div class="tab-pane fade @(merchantsActive ? "show active" : "")" id="merchants-tab" role="tabpanel" aria-labelledby="merchants-tabBtn">
+        @{ var unprovisionedCount = Model.Merchants.Count(m => !m.IsProvisioned); }
+        @if (unprovisionedCount > 0)
         {
             <div class="mb-4">
-                <form method="post" asp-action="ProvisionAll" asp-route-appId="@appId" class="d-inline">
-                    <button type="submit" class="btn btn-success">Provision All</button>
+                <form method="post" asp-action="ProvisionAll" asp-route-appId="@appId" class="d-inline"
+                      onsubmit="return confirm('Provision @unprovisionedCount merchant(s)? This creates a real user, store and POS app for each.');">
+                    <button type="submit" class="btn btn-success">Provision All (@unprovisionedCount)</button>
                 </form>
+            </div>
+        }
+
+        @if (Model.Merchants.Count == 0)
+        {
+            <div class="text-center text-secondary border rounded py-5 mb-3">
+                <p class="mb-1 fw-semibold">No merchants yet</p>
+                <p class="mb-0">Add rows below, or import a CSV, then <strong>Provision</strong> to create their stores.</p>
             </div>
         }
 
@@ -122,8 +147,9 @@
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach (var merchant in Model.Merchants)
+                            @for (var i = 0; i < Model.Merchants.Count; i++)
                             {
+                                var merchant = Model.Merchants[i];
                                 <tr class="@(merchant.HasError ? "table-danger" : "")">
                                     <td>@merchant.Email</td>
                                     <td>
@@ -137,7 +163,7 @@
                                         }
                                     </td>
                                     <td>@(merchant.Currency ?? "Default")</td>
-                                    <td>@(merchant.Spread?.ToString("0.##") ?? "Default")%</td>
+                                    <td>@(merchant.Spread.HasValue ? merchant.Spread.Value.ToString("0.##") + "%" : "Default")</td>
                                     <td>
                                         @if (merchant.HasError)
                                         {
@@ -188,8 +214,7 @@
                                                 <button type="submit" class="btn btn-link btn-sm p-0 text-warning">Repair</button>
                                             </form>
                                         }
-                                        @{var editBtnModalId = merchant.Email.Replace("@@", "_").Replace(".", "_").Replace("+", "_");}
-                                        <a href="#" data-bs-toggle="modal" data-bs-target="#editMerchant-@editBtnModalId">Edit</a>
+                                        <a href="#" class="btn btn-link btn-sm p-0" data-bs-toggle="modal" data-bs-target="#editMerchant-@i">Edit</a>
                                         <span class="text-muted mx-1">·</span>
                                         <form method="post" asp-action="RemoveMerchant" asp-route-appId="@appId" class="d-inline"
                                               onsubmit="return confirm('Remove this merchant? Their store will be archived.');">
@@ -223,10 +248,10 @@
         </div>
 
         <!-- Edit Modals -->
-        @foreach (var merchant in Model.Merchants)
+        @for (var i = 0; i < Model.Merchants.Count; i++)
         {
-            var editModalId = merchant.Email.Replace("@@", "_").Replace(".", "_").Replace("+", "_");
-            <div class="modal fade" id="editMerchant-@editModalId" tabindex="-1">
+            var merchant = Model.Merchants[i];
+            <div class="modal fade" id="editMerchant-@i" tabindex="-1">
                 <div class="modal-dialog">
                     <div class="modal-content">
                         <form method="post" asp-action="UpdateMerchant" asp-route-appId="@appId">
@@ -284,9 +309,9 @@
     </div>
 
     <!-- Reports Tab -->
-    @if (Model.Merchants.Any(m => m.IsProvisioned))
+    @if (hasReports)
     {
-        <div class="tab-pane fade @(activeTab == "reports" ? "show active" : "")" id="reports-tab" role="tabpanel">
+        <div class="tab-pane fade @(reportsActive ? "show active" : "")" id="reports-tab" role="tabpanel" aria-labelledby="reports-tabBtn">
             <div class="btn-group mb-4" role="group">
                 @foreach (var range in new[] { ReportTimeRange.Today, ReportTimeRange.Yesterday, ReportTimeRange.Last7Days })
                 {
@@ -318,19 +343,12 @@
                             <div class="h3">@total.Value.ToString("N2") <span class="text-secondary fw-semibold" style="font-size: .65em">@total.Key</span></div>
                         </div>
                     }
-                    @if (Model.Report.MerchantReports.Count > 0)
+                    @foreach (var received in Model.Report.TotalsReceivedByCurrency)
                     {
-                        @foreach (var group in Model.Report.MerchantReports
-                            .Where(r => r.PaymentBreakdown.Count > 0)
-                            .SelectMany(r => r.PaymentBreakdown.Values)
-                            .GroupBy(p => p.Currency)
-                            .Select(g => new { Currency = g.Key, Total = g.Sum(p => p.TotalAmount) }))
-                        {
-                            <div class="store-number">
-                                <header><h6>Received (@group.Currency)</h6></header>
-                                <div class="h3">@group.Total.ToString("N8") <span class="text-secondary fw-semibold" style="font-size: .65em">@group.Currency</span></div>
-                            </div>
-                        }
+                        <div class="store-number">
+                            <header><h6>Received (@received.Key)</h6></header>
+                            <div class="h3">@received.Value.ToString("N8") <span class="text-secondary fw-semibold" style="font-size: .65em">@received.Key</span></div>
+                        </div>
                     }
                 </div>
 
@@ -342,7 +360,7 @@
                                 <th>Store Name</th>
                                 <th class="text-end">Invoices</th>
                                 <th class="text-end">Sales</th>
-                                <th class="text-end">Payments</th>
+                                <th class="text-end">Received</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -399,13 +417,9 @@
                                     }
                                 </td>
                                 <td class="text-end">
-                                    @foreach (var group in Model.Report.MerchantReports
-                                        .Where(r => r.PaymentBreakdown.Count > 0)
-                                        .SelectMany(r => r.PaymentBreakdown.Values)
-                                        .GroupBy(p => p.Currency)
-                                        .Select(g => new { Currency = g.Key, Total = g.Sum(p => p.TotalAmount) }))
+                                    @foreach (var received in Model.Report.TotalsReceivedByCurrency)
                                     {
-                                        <span class="d-block">@group.Total.ToString("N8") <span class="text-secondary">@group.Currency</span></span>
+                                        <span class="d-block">@received.Value.ToString("N8") <span class="text-secondary">@received.Key</span></span>
                                     }
                                 </td>
                             </tr>


### PR DESCRIPTION
## Summary

A UX review + cleanup pass over the Conference plugin. Fixes one real bug (the Edit-merchant modal never opened), collapses an N+1 on the settings page, and tidies the settings view. Bumps `1.1.0` → `1.2.0`.

## Fixes

- **Edit-merchant modal was broken for real emails.** The modal id was built with `Replace("@@", "_")` inside a Razor `@{}` block. There, `"@@"` is a literal two-character string, *not* the markup `@`-escape — the generated view C# confirms it compiled to a no-op for a normal single-`@` email. So `alice@example.com` became `alice@example_com` and landed in `data-bs-target="#editMerchant-alice@example_com"`; `@` isn't valid in a CSS `#id` selector, so Bootstrap couldn't open the modal. Secondary bug: `.` and `+` both mapped to `_`, so `a.b@x.com` and `a+b@x.com` collided onto the same id. Now keyed off the merchant's row index.

## Performance

- **Settings page ran N×3 sequential DB queries.** `BuildSettingsViewModel` called `CheckMerchantHealth` per merchant — each doing `FindByIdAsync` + `FindStore` + `GetApp`, awaited in a loop. New `CheckMerchantHealthBatch` issues **three** set-based queries (`WHERE Id IN (…)`) for the whole roster and maps in memory. Archived semantics preserved (`GetStores`/`FindStore` both ignore `Archived`; `GetApps(includeArchived: true)` mirrors `GetApp(includeArchived: true)`).

## UX

- **Provision All** now confirms and shows the count — it creates real users, stores and POS apps.
- **Reports**: unified the crypto total label to **Received** (was "Payments" in the table vs "Received" in the widgets); the duplicated per-currency aggregation is hoisted into `ConferenceReport.TotalsReceivedByCurrency`.
- Spread no longer renders `Default%`; empty-roster state on the Merchants tab; consistent action buttons; tab `aria-*` attributes; a short in-app overview + a `README`.

## Verification

- Clean C#/Razor compile; the modal-id fix confirmed in the generated view source (the id is now a plain integer index, no `@`); batch health semantics matched to the originals.
- Not yet exercised in a browser — the local running instance is a separate checkout, so live in-browser confirmation of the Edit modal is still pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-currency received totals to conference reports, with matching totals in the reports table.
  * Enhanced merchants UI with “Provision All” (including unprovisioned count), better empty states, and improved tab/pane activation.
* **Bug Fixes**
  * Improved merchant health checking performance by using batched lookups.
  * Updated merchant edit dialog targeting for more reliable editing.
* **Documentation**
  * Added comprehensive Conference app documentation and setup guidance.
* **Chores**
  * Updated the Conference plugin version to **1.2.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->