### PR TITLE
Electrum: harden coexistence for a full NBX outage

### DIFF
--- a/BTCPayServer.Plugins.Tests/Electrum/ElectrumCoexistenceTests.cs
+++ b/BTCPayServer.Plugins.Tests/Electrum/ElectrumCoexistenceTests.cs
@@ -9,6 +9,7 @@ using NBXplorer.DerivationStrategy;
 using BTCPayServer.Plugins.Electrum.Controllers;
 using BTCPayServer.Plugins.Electrum.Services;
 using BTCPayServer.Events;
+using BTCPayServer.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -420,5 +421,105 @@ public class ElectrumCoexistenceTests : ElectrumCoexistenceTestsBase
         // Once NBX recovers, subsequent evaluations agree Nbx again; it never left Nbx.
         await ElectrumTestInfra.ForceBackendAsync(coordinator, walletId, WalletBackend.Nbx, ct);
         Assert.Equal(WalletBackend.Nbx, coordinator.GetActiveBackend(walletId));
+    }
+
+    [Fact(Timeout = 180_000)]
+    [Trait("Integration", "Integration")]
+    public async Task NbxDown_GlobalReadFallsBackToElectrum_AndHealthFlips()
+    {
+        using var tester = CreateElectrumServerTester();
+        await tester.StartAsync();
+        var ct = TestContext.Current.CancellationToken;
+
+        await ElectrumTestInfra.PointElectrumAtFulcrumAsync(tester, ct);
+
+        // The store-facing ExplorerClient shim: its REST transport is ElectrumHttpHandler, so
+        // these calls exercise the real routing (proxy-to-NBX vs serve-from-Electrum).
+        var network = tester.PayTester.GetService<BTCPayNetworkProvider>().GetNetwork<BTCPayNetwork>("BTC");
+        var shim = tester.PayTester.GetService<ExplorerClientProvider>().GetExplorerClient(network);
+        var health = tester.PayTester.GetService<NbxHealth>();
+
+        // Sanity: with NBX up, a Global read resolves.
+        Assert.NotNull(await shim.GetStatusAsync(ct));
+
+        try
+        {
+            ElectrumTestInfra.StopNbx();
+
+            // A GlobalRead (status) through the shim must NOT throw with NBX down: the router tries
+            // NBX, catches the transport failure, marks NBX unreachable, and serves from the
+            // Electrum engine. Broadcast takes the identical routing path, so this also covers the
+            // send-during-outage fallback.
+            await TestUtils.EventuallyAsync(async () =>
+            {
+                var status = await shim.GetStatusAsync(ct);
+                Assert.NotNull(status);
+                Assert.False(health.Reachable);
+            }, delay: 30_000);
+        }
+        finally
+        {
+            ElectrumTestInfra.StartNbx();
+        }
+    }
+
+    [Fact(Timeout = 240_000)]
+    [Trait("Integration", "Integration")]
+    public async Task NbxRecovery_FiresRescan_AndNbxRediscoversOutageActivity()
+    {
+        using var tester = CreateElectrumServerTester();
+        await tester.StartAsync();
+        var ct = TestContext.Current.CancellationToken;
+
+        await ElectrumTestInfra.PointElectrumAtFulcrumAsync(tester, ct);
+
+        var user = tester.NewAccount();
+        user.GrantAccess();
+        user.RegisterDerivationScheme("BTC");
+        var walletId = user.DerivationScheme.ToString();
+
+        var health = tester.PayTester.GetService<NbxHealth>();
+        var recovered = false;
+        health.OnRecovered += () => recovered = true;
+
+        var coordinator = tester.PayTester.GetService<BackendCoordinator>();
+        var realNbx = tester.PayTester.GetService<RealNbxGateway>();
+        var network = tester.PayTester.GetService<BTCPayNetworkProvider>().GetNetwork<BTCPayNetwork>("BTC");
+        var strategy = new DerivationStrategyFactory(network.NBitcoinNetwork).Parse(walletId);
+        var depositAddress = user.DerivationScheme
+            .GetLineFor(DerivationFeature.Deposit).Derive(2)
+            .ScriptPubKey.GetDestinationAddress(network.NBitcoinNetwork);
+
+        try
+        {
+            // NBX goes down; one evaluation flips the shared health flag to unreachable.
+            ElectrumTestInfra.StopNbx();
+            await coordinator.EvaluateWalletAsync(walletId, ct);
+            Assert.False(health.Reachable);
+
+            // Funds arrive while NBX is down (only the Electrum engine could see them live).
+            await tester.ExplorerNode.SendToAddressAsync(depositAddress, Money.Coins(0.4m));
+            tester.ExplorerNode.Generate(1);
+
+            // NBX comes back (StartNbx blocks until it reports synced); one evaluation records it
+            // reachable again, which fires OnRecovered -> the coordinator rescans tracked wallets.
+            ElectrumTestInfra.StartNbx();
+            await coordinator.EvaluateWalletAsync(walletId, ct);
+            Assert.True(recovered, "NBX recovery did not fire the rescan trigger");
+
+            // Recovery data-sync: after NBX's own chain re-index + the triggered rescan, NBX must
+            // rediscover the payment that arrived during the outage.
+            var nbx = realNbx.GetClient("BTC");
+            await TestUtils.EventuallyAsync(async () =>
+            {
+                var utxos = await nbx.GetUTXOsAsync(strategy, ct);
+                Assert.Contains(utxos.Confirmed.UTXOs, u => u.Value is Money m && m == Money.Coins(0.4m));
+            }, delay: 150_000);
+        }
+        finally
+        {
+            if (!health.Reachable)
+                ElectrumTestInfra.StartNbx();
+        }
     }
 }

--- a/BTCPayServer.Plugins.Tests/Electrum/ElectrumCoexistenceTests.cs
+++ b/BTCPayServer.Plugins.Tests/Electrum/ElectrumCoexistenceTests.cs
@@ -490,10 +490,12 @@ public class ElectrumCoexistenceTests : ElectrumCoexistenceTestsBase
             .GetLineFor(DerivationFeature.Deposit).Derive(2)
             .ScriptPubKey.GetDestinationAddress(network.NBitcoinNetwork);
 
+        var nbxStopped = false;
         try
         {
             // NBX goes down; one evaluation flips the shared health flag to unreachable.
             ElectrumTestInfra.StopNbx();
+            nbxStopped = true;
             await coordinator.EvaluateWalletAsync(walletId, ct);
             Assert.False(health.Reachable);
 
@@ -504,6 +506,7 @@ public class ElectrumCoexistenceTests : ElectrumCoexistenceTestsBase
             // NBX comes back (StartNbx blocks until it reports synced); one evaluation records it
             // reachable again, which fires OnRecovered -> the coordinator rescans tracked wallets.
             ElectrumTestInfra.StartNbx();
+            nbxStopped = false;
             await coordinator.EvaluateWalletAsync(walletId, ct);
             Assert.True(recovered, "NBX recovery did not fire the rescan trigger");
 
@@ -518,7 +521,7 @@ public class ElectrumCoexistenceTests : ElectrumCoexistenceTestsBase
         }
         finally
         {
-            if (!health.Reachable)
+            if (nbxStopped)
                 ElectrumTestInfra.StartNbx();
         }
     }

--- a/Plugins/BTCPayServer.Plugins.Electrum/ElectrumPlugin.cs
+++ b/Plugins/BTCPayServer.Plugins.Electrum/ElectrumPlugin.cs
@@ -110,6 +110,10 @@ public class ElectrumPlugin : BaseBTCPayServerPlugin
         // Direct real-NBX gateway (used by coordinator and routing handler proxy)
         services.AddSingleton<RealNbxGateway>();
 
+        // Shared NBX reachability signal: lets the routing handler fall back to Electrum when
+        // NBX is actually down (not just absent) and triggers a rescan when NBX recovers.
+        services.AddSingleton<NbxHealth>();
+
         // ──────────────────────────────────────────────
         // 4. Register shadow services
         // ──────────────────────────────────────────────

--- a/Plugins/BTCPayServer.Plugins.Electrum/Services/BackendCoordinator.cs
+++ b/Plugins/BTCPayServer.Plugins.Electrum/Services/BackendCoordinator.cs
@@ -31,6 +31,7 @@ public class BackendCoordinator : IHostedService
     private readonly BTCPayNetworkProvider _networkProvider;
     private readonly IndexFastForwarder _fastForwarder;
     private readonly ReservedIndexLedger _reservedLedger;
+    private readonly NbxHealth _nbxHealth;
     private readonly ILogger<BackendCoordinator> _logger;
     private CancellationTokenSource _cts;
     private Task _pollTask;
@@ -44,6 +45,7 @@ public class BackendCoordinator : IHostedService
         BTCPayNetworkProvider networkProvider = null,
         IndexFastForwarder fastForwarder = null,
         ReservedIndexLedger reservedLedger = null,
+        NbxHealth nbxHealth = null,
         ILogger<BackendCoordinator> logger = null)
     {
         _dbFactory = dbFactory;
@@ -51,6 +53,7 @@ public class BackendCoordinator : IHostedService
         _networkProvider = networkProvider;
         _fastForwarder = fastForwarder;
         _reservedLedger = reservedLedger;
+        _nbxHealth = nbxHealth;
         _logger = logger;
     }
 
@@ -105,12 +108,16 @@ public class BackendCoordinator : IHostedService
             return Task.CompletedTask; // not wired for polling (e.g. constructed directly in a test)
 
         _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (_nbxHealth != null)
+            _nbxHealth.OnRecovered += OnNbxRecovered;
         _pollTask = Task.Run(() => PollLoopAsync(_cts.Token), CancellationToken.None);
         return Task.CompletedTask;
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
+        if (_nbxHealth != null)
+            _nbxHealth.OnRecovered -= OnNbxRecovered;
         _cts?.Cancel();
         if (_pollTask != null)
         {
@@ -221,10 +228,12 @@ public class BackendCoordinator : IHostedService
             try
             {
                 var status = await nbx.GetStatusAsync(ct);
+                _nbxHealth?.Record(true);
                 nbxSynced = status?.IsFullySynched ?? false;
             }
             catch (Exception ex)
             {
+                _nbxHealth?.Record(false);
                 _logger?.LogDebug(ex, "Failed to read NBX status; treating as not synced");
             }
 
@@ -339,6 +348,66 @@ public class BackendCoordinator : IHostedService
                 {
                     _logger?.LogDebug(ex, "Failed to read NBX next index for wallet {WalletId} feature {Feature} during ledger seed", wallet.Id, feature);
                 }
+            }
+        }
+    }
+
+    // When NBX comes back after an outage, ask it to rescan each tracked wallet's UTXO set so any
+    // activity that arrived while it was down is rediscovered — belt-and-suspenders on top of NBX's
+    // own chain re-index. Fire-and-forget; a wallet won't flip back to NBX-authoritative until NBX
+    // reports fully synced anyway, so there's no rush.
+    private void OnNbxRecovered()
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await RescanAllTrackedInNbxAsync(_cts?.Token ?? CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Rescan on NBX recovery failed");
+            }
+        });
+    }
+
+    private async Task RescanAllTrackedInNbxAsync(CancellationToken ct)
+    {
+        if (_realNbx == null || _networkProvider == null || _dbFactory == null)
+            return;
+
+        List<TrackedWallet> wallets;
+        try
+        {
+            await using var ctx = _dbFactory.CreateContext();
+            wallets = await ctx.TrackedWallets.ToListAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to load tracked wallets for NBX recovery rescan");
+            return;
+        }
+
+        foreach (var wallet in wallets)
+        {
+            var nbx = _realNbx.GetClient(wallet.CryptoCode);
+            if (nbx == null)
+                continue;
+
+            var network = _networkProvider.GetNetwork<BTCPayNetwork>(wallet.CryptoCode);
+            if (network == null)
+                continue;
+
+            try
+            {
+                var strategy = new DerivationStrategyFactory(network.NBitcoinNetwork).Parse(wallet.DerivationStrategy);
+                await nbx.ScanUTXOSetAsync(strategy, cancellation: ct);
+                _logger?.LogInformation("Requested NBX UTXO rescan for wallet {WalletId} after NBX recovery", wallet.Id);
+            }
+            catch (Exception ex)
+            {
+                // Includes NBX's "scanutxoset-in-progress" when a scan is already scheduled — harmless.
+                _logger?.LogDebug(ex, "NBX recovery rescan skipped/failed for wallet {WalletId}", wallet.Id);
             }
         }
     }

--- a/Plugins/BTCPayServer.Plugins.Electrum/Services/ElectrumHttpHandler.cs
+++ b/Plugins/BTCPayServer.Plugins.Electrum/Services/ElectrumHttpHandler.cs
@@ -31,6 +31,7 @@ public class ElectrumHttpHandler : HttpMessageHandler
     private readonly BackendCoordinator _coordinator;
     private readonly RealNbxGateway _realNbx;
     private readonly ReservedIndexLedger _reservedLedger;
+    private readonly NbxHealth _nbxHealth;
     private readonly ILogger<ElectrumHttpHandler> _logger;
 
     public ElectrumHttpHandler(
@@ -39,6 +40,7 @@ public class ElectrumHttpHandler : HttpMessageHandler
         BackendCoordinator coordinator,
         RealNbxGateway realNbx,
         ReservedIndexLedger reservedLedger,
+        NbxHealth nbxHealth,
         ILogger<ElectrumHttpHandler> logger)
     {
         _tracker = tracker;
@@ -46,6 +48,7 @@ public class ElectrumHttpHandler : HttpMessageHandler
         _coordinator = coordinator;
         _realNbx = realNbx;
         _reservedLedger = reservedLedger;
+        _nbxHealth = nbxHealth;
         _logger = logger;
     }
 
@@ -65,29 +68,48 @@ public class ElectrumHttpHandler : HttpMessageHandler
             // unchanged.
             var call = NbxRequestClassifier.Classify(method, path, request.RequestUri?.Query ?? "");
             var routeCryptoCode = ExtractCryptoCode(path) ?? "BTC";
+            // NBX is only usable if a client exists AND it is currently reachable. Without the
+            // reachability gate, Global reads (/status, /fees) and broadcasts route to a dead NBX
+            // and fail; with it they fall through to the Electrum engine. It also covers the ~poll
+            // window where a wallet is still pinned to Nbx but NBX just went down (fast failback).
+            var nbxUsable = _realNbx.GetClient(routeCryptoCode) != null && _nbxHealth.Reachable;
             var useNbx = call.Kind switch
             {
                 NbxCallKind.WalletRead or NbxCallKind.WalletMutate => call.WalletId != null
-                    && _coordinator.GetActiveBackend(call.WalletId) == WalletBackend.Nbx,
-                NbxCallKind.GlobalRead or NbxCallKind.Broadcast => _realNbx.GetClient(routeCryptoCode) != null, // refined in P3
+                    && _coordinator.GetActiveBackend(call.WalletId) == WalletBackend.Nbx && nbxUsable,
+                NbxCallKind.GlobalRead or NbxCallKind.Broadcast => nbxUsable,
                 _ => false
             };
-            if (useNbx && _realNbx.GetClient(routeCryptoCode) != null)
+            if (useNbx)
             {
-                _logger.LogDebug("Routing {Method} {Path} to real NBX ({Kind})", method, path, call.Kind);
-                var proxied = await ProxyToRealNbxAsync(request, cancellationToken);
-
-                // The "reserve new address" mutation is proxied verbatim above, but the
-                // reserved-index ledger must stay authoritative regardless of which backend
-                // actually served it — peek the response and record the reserved index.
-                if (call.Kind == NbxCallKind.WalletMutate && call.WalletId != null &&
-                    path.Contains("/addresses/unused"))
+                try
                 {
-                    proxied = await PeekAndRecordNbxReserveAsync(
-                        proxied, call.WalletId, routeCryptoCode, cancellationToken);
-                }
+                    _logger.LogDebug("Routing {Method} {Path} to real NBX ({Kind})", method, path, call.Kind);
+                    var proxied = await ProxyToRealNbxAsync(request, cancellationToken);
 
-                return proxied;
+                    // The "reserve new address" mutation is proxied verbatim above, but the
+                    // reserved-index ledger must stay authoritative regardless of which backend
+                    // actually served it — peek the response and record the reserved index.
+                    if (call.Kind == NbxCallKind.WalletMutate && call.WalletId != null &&
+                        path.Contains("/addresses/unused"))
+                    {
+                        proxied = await PeekAndRecordNbxReserveAsync(
+                            proxied, call.WalletId, routeCryptoCode, cancellationToken);
+                    }
+
+                    return proxied;
+                }
+                catch (Exception ex) when (
+                    ex is HttpRequestException or System.IO.IOException ||
+                    (ex is OperationCanceledException && !cancellationToken.IsCancellationRequested))
+                {
+                    // NBX became unreachable between the reachability check and the call (a timeout
+                    // or connection failure not caused by the caller cancelling). Mark it down so
+                    // subsequent calls skip it immediately, and fall through to serve this one from
+                    // the Electrum engine below instead of failing the request.
+                    _nbxHealth.Record(false);
+                    _logger.LogWarning(ex, "NBX proxy failed for {Method} {Path}; falling back to Electrum", method, path);
+                }
             }
 
             // POST /v1/cryptos/{code}/derivations — GenerateWallet or Track

--- a/Plugins/BTCPayServer.Plugins.Electrum/Services/ElectrumHttpHandler.cs
+++ b/Plugins/BTCPayServer.Plugins.Electrum/Services/ElectrumHttpHandler.cs
@@ -26,6 +26,11 @@ public class ElectrumHttpHandler : HttpMessageHandler
 {
     private static readonly HttpClient _proxyClient = new();
 
+    // Bound each proxy attempt so a hung (not merely refused) NBX fails over to Electrum quickly,
+    // instead of blocking on HttpClient's default ~100s timeout. Only the first call per outage
+    // pays this — once it trips NbxHealth to unreachable, subsequent calls skip NBX entirely.
+    private static readonly TimeSpan ProxyTimeout = TimeSpan.FromSeconds(20);
+
     private readonly ElectrumWalletTracker _tracker;
     private readonly BTCPayNetworkProvider _networkProvider;
     private readonly BackendCoordinator _coordinator;
@@ -561,7 +566,9 @@ public class ElectrumHttpHandler : HttpMessageHandler
                 clone.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
         }
 
-        return await _proxyClient.SendAsync(clone, cancellationToken);
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(ProxyTimeout);
+        return await _proxyClient.SendAsync(clone, timeoutCts.Token);
     }
 
     // Peeks the buffered body of a proxied "reserve new address" response so the reserved-

--- a/Plugins/BTCPayServer.Plugins.Electrum/Services/ElectrumStatusMonitor.cs
+++ b/Plugins/BTCPayServer.Plugins.Electrum/Services/ElectrumStatusMonitor.cs
@@ -23,6 +23,7 @@ public class ElectrumStatusMonitor : IHostedService
     private readonly EventAggregator _eventAggregator;
     private readonly SettingsRepository _settingsRepository;
     private readonly RealNbxGateway _realNbxGateway;
+    private readonly NbxHealth _nbxHealth;
     private readonly ILogger<ElectrumStatusMonitor> _logger;
     private CancellationTokenSource _cts;
     private Task _monitorLoop;
@@ -48,6 +49,7 @@ public class ElectrumStatusMonitor : IHostedService
         EventAggregator eventAggregator,
         SettingsRepository settingsRepository,
         RealNbxGateway realNbxGateway,
+        NbxHealth nbxHealth,
         ILogger<ElectrumStatusMonitor> logger)
     {
         _client = client;
@@ -56,6 +58,7 @@ public class ElectrumStatusMonitor : IHostedService
         _eventAggregator = eventAggregator;
         _settingsRepository = settingsRepository;
         _realNbxGateway = realNbxGateway;
+        _nbxHealth = nbxHealth;
         _logger = logger;
     }
 
@@ -158,10 +161,12 @@ public class ElectrumStatusMonitor : IHostedService
         try
         {
             var status = await client.GetStatusAsync(ct);
+            _nbxHealth.Record(true);
             return status?.IsFullySynched is true;
         }
         catch (Exception ex)
         {
+            _nbxHealth.Record(false);
             _logger.LogDebug(ex, "Failed to query real NBX status");
             return false;
         }

--- a/Plugins/BTCPayServer.Plugins.Electrum/Services/NbxHealth.cs
+++ b/Plugins/BTCPayServer.Plugins.Electrum/Services/NbxHealth.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using System;
+using System.Threading;
+
+namespace BTCPayServer.Plugins.Electrum.Services;
+
+/// <summary>
+/// Shared, cached view of whether the real NBXplorer is currently reachable. Maintained by every
+/// component that talks to real NBX (the coordinator's poll, the status monitor, and the routing
+/// handler's proxy), so the handler can avoid routing Global reads / broadcasts to a dead NBX
+/// (falling back to the Electrum engine instead) rather than only checking that a client object
+/// exists. Fires <see cref="OnRecovered"/> once per unreachable→reachable transition so tracked
+/// wallets can be re-scanned in NBX after an outage.
+/// </summary>
+public class NbxHealth
+{
+    // 1 = reachable, 0 = unreachable. Starts optimistic; the first real NBX interaction corrects it.
+    private int _reachable = 1;
+
+    public bool Reachable => Volatile.Read(ref _reachable) == 1;
+
+    /// <summary>Raised (once per transition) when NBX goes from unreachable back to reachable.</summary>
+    public event Action? OnRecovered;
+
+    public void Record(bool reachable)
+    {
+        var previous = Interlocked.Exchange(ref _reachable, reachable ? 1 : 0);
+        if (reachable && previous == 0)
+            OnRecovered?.Invoke();
+    }
+}


### PR DESCRIPTION
Follow-up to #134. Hardens the two failure-mode gaps that surfaced when reviewing "what if NBXplorer is fully down (not just absent)".

## Gaps

1. **Sending broke during an NBX outage.** Global reads (`/status`, `/fees`) and broadcasts were routed to NBX purely on *client existence* (`RealNbxGateway.GetClient() != null`), with no health check — so with NBX down they were proxied to a dead endpoint and failed, instead of falling back to the Electrum engine. Net: you could *receive* during an outage but not *send*.
2. **No recovery re-sync.** Nothing re-scanned tracked wallets when NBX came back; recovery relied entirely on NBX's own chain re-index.

## Fixes

- **`NbxHealth`** — a shared, cached reachability flag maintained by every component that talks to real NBX (the coordinator poll, the status monitor, and the routing handler's proxy). The handler now:
  - gates routing on reachability (Global reads / broadcast / a wallet still pinned to Nbx a poll before failback go to Electrum when NBX is down), and
  - if a proxied call fails mid-flight (connection error or timeout **not** caused by the caller cancelling), marks NBX down and **serves that request from the Electrum engine** instead of failing it.
- **Recovery rescan** — on the unreachable→reachable transition, `NbxHealth` fires `OnRecovered`; the coordinator re-scans every tracked wallet's UTXO set in NBX so activity from the outage is rediscovered (belt-and-suspenders on top of NBX's re-index). A wallet won't flip back to NBX-authoritative until NBX reports fully synced anyway.

## Tests (both new, against the regtest Fulcrum stack)

- `NbxDown_GlobalReadFallsBackToElectrum_AndHealthFlips` — with NBX stopped, a Global read through the store-facing shim resolves (served by Electrum) and `NbxHealth.Reachable` flips false. Broadcast takes the identical routing path.
- `NbxRecovery_FiresRescan_AndNbxRediscoversOutageActivity` — funds arrive while NBX is down; after NBX restarts, `OnRecovered` fires and NBX rediscovers the outage payment.

Full Electrum suite: **11 passed, 0 failed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved backend failover so wallet reads and broadcasts can continue when the primary service is unreachable.
  * Added automatic recovery handling that triggers a rescan after connectivity returns.
* **Bug Fixes**
  * Better detects backend outages and restores access more smoothly.
  * Ensures activity that happened during an outage is rediscovered after recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->