### PR TITLE
Blink: support non-custodial (Spark) accounts for receiving

### DIFF
--- a/Plugins/BTCPayServer.Plugins.Blink/BTCPayServer.Plugins.Blink.csproj
+++ b/Plugins/BTCPayServer.Plugins.Blink/BTCPayServer.Plugins.Blink.csproj
@@ -9,7 +9,7 @@
     <PropertyGroup>
         <Product>Blink</Product>
         <Description>Blink Lightning support</Description>
-        <Version>1.0.15</Version>
+        <Version>1.1.0</Version>
 <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <RootNamespace>BTCPayServer.Plugins.Blink</RootNamespace>
     </PropertyGroup>

--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningConnectionStringHandler.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningConnectionStringHandler.cs
@@ -30,6 +30,15 @@ public class BlinkLightningConnectionStringHandler : ILightningConnectionStringH
             return null;
         }
 
+        // Non-custodial (Spark) accounts: identified by an "ln-address" (or bare "username") key
+        // and the absence of an "api-key". These have no GraphQL wallet-id and can only receive,
+        // via LNURL-pay + LUD-21 verify brokered by blink-lnurl-server.
+        if (!kv.ContainsKey("api-key") &&
+            (kv.TryGetValue("ln-address", out var lnAddress) || kv.TryGetValue("username", out lnAddress)))
+        {
+            return CreateLnAddressClient(lnAddress, kv, network, out error);
+        }
+
         if (!kv.TryGetValue("server", out var server))
         {
             server = network.Name switch
@@ -98,5 +107,47 @@ public class BlinkLightningConnectionStringHandler : ILightningConnectionStringH
             }
         }
         return new BlinkLightningClient(apiKey, uri, walletId, currency, network, client, _loggerFactory.CreateLogger(nameof(BlinkLightningClient)));
+    }
+
+    private ILightningClient? CreateLnAddressClient(string? lnAddress,
+        System.Collections.Generic.Dictionary<string, string> kv, Network network, out string? error)
+    {
+        if (string.IsNullOrWhiteSpace(lnAddress))
+        {
+            error = "The key 'ln-address' must be a Blink lightning address (e.g. user@blink.sv)";
+            return null;
+        }
+
+        // Allow a bare username; default the domain to blink.sv.
+        if (!lnAddress.Contains('@'))
+            lnAddress = $"{lnAddress}@blink.sv";
+
+        var atParts = lnAddress.Split('@');
+        if (atParts.Length != 2 || string.IsNullOrWhiteSpace(atParts[0]) || string.IsNullOrWhiteSpace(atParts[1]))
+        {
+            error = $"The key 'ln-address' is not a valid lightning address ('{lnAddress}')";
+            return null;
+        }
+
+        // USDB (non-custodial Dollar balance) is requested via currency=USD. Not yet live server-side;
+        // passed through so it works automatically once Blink ships Spark USD receive support.
+        bool usd = false;
+        if (kv.TryGetValue("currency", out var currencyStr))
+        {
+            try
+            {
+                usd = BlinkLightningClient.ParseBlinkCurrency(currencyStr) == BlinkCurrency.USD;
+            }
+            catch (FormatException e)
+            {
+                error = e.Message;
+                return null;
+            }
+        }
+
+        error = null;
+        var client = _httpClientFactory.CreateClient();
+        return new BlinkLnAddressLightningClient(lnAddress, usd, network, client,
+            _loggerFactory.CreateLogger(nameof(BlinkLnAddressLightningClient)));
     }
 }

--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningConnectionStringHandler.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningConnectionStringHandler.cs
@@ -147,6 +147,9 @@ public class BlinkLightningConnectionStringHandler : ILightningConnectionStringH
 
         error = null;
         var client = _httpClientFactory.CreateClient();
+        // Bound each LNURL/verify request rather than inheriting the default 100s HttpClient timeout,
+        // so a degraded blink-lnurl-server cannot tie up a connection per poll for that long.
+        client.Timeout = TimeSpan.FromSeconds(30);
         return new BlinkLnAddressLightningClient(lnAddress, usd, network, client,
             _loggerFactory.CreateLogger(nameof(BlinkLnAddressLightningClient)));
     }

--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkLnAddressLightningClient.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkLnAddressLightningClient.cs
@@ -54,6 +54,26 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
     private ConcurrentDictionary<string, TrackedInvoice> _tracked =>
         _sharedTracked.GetOrAdd(_lightningAddress, _ => new ConcurrentDictionary<string, TrackedInvoice>());
 
+    /// <summary>
+    /// Removes a tracked invoice and prunes the outer address entry once it is empty, so the static
+    /// registry stays bounded by the number of currently-open invoices rather than growing for every
+    /// lightning address ever configured.
+    /// </summary>
+    private void RemoveTrackedInvoice(string paymentHash)
+    {
+        if (!_sharedTracked.TryGetValue(_lightningAddress, out var inner))
+            return;
+        inner.TryRemove(paymentHash, out _);
+        if (inner.IsEmpty)
+        {
+            // Only remove the outer key if it is still the (now-empty) instance we just pruned, to
+            // avoid dropping a dictionary that another thread has concurrently repopulated.
+            _sharedTracked.TryRemove(
+                new System.Collections.Generic.KeyValuePair<string, ConcurrentDictionary<string, TrackedInvoice>>(
+                    _lightningAddress, inner));
+        }
+    }
+
     // The origin (scheme://host[:port]) of the LNURL-pay callback, which is also the host that
     // serves the LUD-21 verify endpoint (e.g. https://lnurl.blink.sv). It is NOT the lightning
     // address domain (blink.sv). Cached so a stateless GetInvoice can rebuild the verify URL.
@@ -187,9 +207,11 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
         if (bolt11.MinimumAmount != LightMoney.MilliSatoshis(amountMsat))
             throw new Exception(
                 $"Blink returned an invoice for {bolt11.MinimumAmount.MilliSatoshi} msat but {amountMsat} msat was requested.");
-        if (createInvoiceRequest.DescriptionHash is { } dh && bolt11.DescriptionHash is { } bh &&
-            dh != bh)
-            throw new Exception("Blink returned an invoice with a mismatched description hash.");
+        // Strict check: if a description hash was requested, the returned invoice must carry the
+        // exact same hash. A missing/stripped `h` tag (bolt11.DescriptionHash == null) is also a
+        // mismatch, so a compromised LNURL server cannot bypass the check by dropping the tag.
+        if (createInvoiceRequest.DescriptionHash is { } dh && dh != bolt11.DescriptionHash)
+            throw new Exception("Blink returned an invoice with a mismatched or missing description hash.");
 
         var paymentHash = bolt11.PaymentHash?.ToString() ?? throw new Exception("Invoice has no payment hash.");
         var verifyUrl = json["verify"]?.Value<string>();
@@ -365,7 +387,12 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
 
     public Task<LightningInvoice[]> ListInvoices(ListInvoicesParams request, CancellationToken cancellation = new())
     {
-        // No server-side invoice list is available for non-custodial accounts; only in-memory tracked invoices.
+        // No server-side invoice list is available for non-custodial accounts; only in-memory tracked
+        // invoices. We report these as Unpaid (settled=false) without issuing a verify call per invoice:
+        // settlement is authoritatively driven through GetInvoice / WaitInvoice, not ListInvoices, and
+        // settled invoices are pruned from the registry by the poll loop, so the only misreport window
+        // is the brief interval between a verify returning Paid and the poll loop's TryRemove. That
+        // window is harmless for BTCPay's payment detection, so we keep this cheap and avoid N HTTP calls.
         var invoices = _tracked
             .Select(kv => BuildInvoice(kv.Key, kv.Value, false, null))
             .Where(i => request.PendingOnly is not true || i.Status == LightningInvoiceStatus.Unpaid)
@@ -386,11 +413,16 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
     public class BlinkLnAddressListener : ILightningInvoiceListener
     {
         private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(3);
+        private static readonly TimeSpan MaxBackoff = TimeSpan.FromSeconds(30);
         private readonly BlinkLnAddressLightningClient _client;
         private readonly ILogger _logger;
         private readonly Channel<LightningInvoice> _channel = Channel.CreateUnbounded<LightningInvoice>();
         private readonly CancellationTokenSource _cts = new();
         private readonly Task _pollTask;
+
+        // Per-invoice error back-off: number of consecutive failures and the earliest next attempt.
+        private readonly System.Collections.Generic.Dictionary<string, (int Errors, DateTimeOffset NextAttempt)>
+            _backoff = new();
 
         public BlinkLnAddressListener(BlinkLnAddressLightningClient client, ILogger logger)
         {
@@ -405,23 +437,30 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
             {
                 while (!cancellation.IsCancellationRequested)
                 {
+                    var now = DateTimeOffset.UtcNow;
                     foreach (var kv in _client._tracked.ToArray())
                     {
                         cancellation.ThrowIfCancellationRequested();
                         var (paymentHash, tracked) = (kv.Key, kv.Value);
+
+                        // Skip this invoice while it is backing off after repeated failures.
+                        if (_backoff.TryGetValue(paymentHash, out var b) && now < b.NextAttempt)
+                            continue;
+
                         try
                         {
                             var invoice = await _client.GetInvoice(paymentHash, cancellation);
+                            _backoff.Remove(paymentHash); // success resets back-off
                             if (invoice is null) continue;
                             if (invoice.Status == LightningInvoiceStatus.Paid)
                             {
-                                _client._tracked.TryRemove(paymentHash, out _);
+                                RemoveTracked(paymentHash);
                                 await _channel.Writer.WriteAsync(invoice, cancellation);
                             }
                             else if (invoice.Status == LightningInvoiceStatus.Expired ||
                                      tracked.ExpiresAt < DateTimeOffset.UtcNow)
                             {
-                                _client._tracked.TryRemove(paymentHash, out _);
+                                RemoveTracked(paymentHash);
                             }
                         }
                         catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
@@ -430,7 +469,14 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
                         }
                         catch (Exception e)
                         {
-                            _logger.LogDebug(e, "Error polling Blink invoice {PaymentHash}", paymentHash);
+                            // Capped exponential back-off so a degraded blink-lnurl-server is not
+                            // hammered every 3s per invoice.
+                            var errors = (_backoff.TryGetValue(paymentHash, out var prev) ? prev.Errors : 0) + 1;
+                            var delayMs = Math.Min(PollInterval.TotalMilliseconds * Math.Pow(2, errors),
+                                MaxBackoff.TotalMilliseconds);
+                            _backoff[paymentHash] = (errors, DateTimeOffset.UtcNow.AddMilliseconds(delayMs));
+                            _logger.LogDebug(e, "Error polling Blink invoice {PaymentHash} (attempt {Errors}); backing off {DelayMs}ms",
+                                paymentHash, errors, delayMs);
                         }
                     }
 
@@ -446,6 +492,12 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
             }
         }
 
+        private void RemoveTracked(string paymentHash)
+        {
+            _client.RemoveTrackedInvoice(paymentHash);
+            _backoff.Remove(paymentHash);
+        }
+
         public async Task<LightningInvoice> WaitInvoice(CancellationToken cancellation)
         {
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellation, _cts.Token);
@@ -455,6 +507,10 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
         public void Dispose()
         {
             _cts.Cancel();
+            // Wait (bounded) for the poll loop to observe cancellation before completing the channel,
+            // so an in-flight WriteAsync cannot race TryComplete and surface a ChannelClosedException.
+            try { _pollTask.Wait(TimeSpan.FromSeconds(5)); }
+            catch { /* AggregateException from cancellation or timeout: ignore on dispose */ }
             _channel.Writer.TryComplete();
             _cts.Dispose();
         }
@@ -511,7 +567,7 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
 
     public Task CancelInvoice(string invoiceId, CancellationToken cancellation = new())
     {
-        _tracked.TryRemove(invoiceId, out _);
+        RemoveTrackedInvoice(invoiceId);
         return Task.CompletedTask;
     }
 

--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkLnAddressLightningClient.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkLnAddressLightningClient.cs
@@ -137,6 +137,12 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
         if (string.IsNullOrEmpty(callback))
             throw new Exception("LNURL-pay response is missing a callback URL.");
 
+        // BTCPay allows a null amount for top-up/amountless invoices, but LNURL-pay is inherently
+        // amount-driven, so we require a concrete amount and fail with a clear message otherwise.
+        if (createInvoiceRequest.Amount is null)
+            throw new NotSupportedException(
+                "Blink non-custodial (Spark) accounts require an invoice amount; amountless/top-up invoices are not supported.");
+
         var amountMsat = createInvoiceRequest.Amount.MilliSatoshi;
         var min = metadata["minSendable"]?.Value<long>() ?? 1;
         var max = metadata["maxSendable"]?.Value<long>() ?? long.MaxValue;
@@ -163,6 +169,10 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
 
         using var resp = await _httpClient.GetAsync(callbackUri.Uri, cancellation);
         var body = await resp.Content.ReadAsStringAsync(cancellation);
+        // Guard the HTTP status before parsing: a non-2xx response may carry a non-JSON body
+        // (e.g. an HTML 500 from the LNURL server), which would otherwise throw an opaque parse error.
+        if (!resp.IsSuccessStatusCode)
+            throw new Exception($"Blink LNURL callback failed (HTTP {(int)resp.StatusCode}).");
         var json = JObject.Parse(body);
         if (json["status"]?.Value<string>()?.Equals("ERROR", StringComparison.OrdinalIgnoreCase) == true)
             throw new Exception(json["reason"]?.Value<string>() ?? "Blink LNURL callback returned an error.");

--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkLnAddressLightningClient.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkLnAddressLightningClient.cs
@@ -1,0 +1,523 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using BTCPayServer.Lightning;
+using BTCPayServer.Payments.Lightning;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NBitcoin.Crypto;
+using NBitcoin.DataEncoders;
+using Newtonsoft.Json.Linq;
+using Network = NBitcoin.Network;
+
+namespace BTCPayServer.Plugins.Blink;
+
+/// <summary>
+/// A receive-only Lightning client for Blink non-custodial (Spark) accounts.
+///
+/// Non-custodial Blink accounts have no API key and no GraphQL wallet-id. The only
+/// server-brokered receive path is LNURL-pay (LUD-06/LUD-16) served by blink-lnurl-server
+/// at https://{domain}/.well-known/lnurlp/{username}. Payment settlement is detected via the
+/// LUD-21 "verify" URL (returns { settled, preimage, pr }).
+///
+/// This client therefore only supports receiving. Sending, balance and channel operations
+/// require the wallet seed and are intentionally not supported.
+/// </summary>
+public class BlinkLnAddressLightningClient : IExtendedLightningClient
+{
+    // "user@domain". For USD (USDB, not yet live server-side) the LNURL username carries a
+    // "+usd" modifier, e.g. "user+usd".
+    private readonly string _lightningAddress;
+    private readonly string _username;
+    private readonly string _domain;
+    private readonly bool _usd;
+    private readonly Network _network;
+    private readonly HttpClient _httpClient;
+    private readonly ILogger _logger;
+
+    private record TrackedInvoice(string Bolt11, string? VerifyUrl, DateTimeOffset ExpiresAt);
+
+    // BTCPay creates SEPARATE client instances for creating invoices and for its payment
+    // listener/poller. In-memory per-instance state would therefore not be visible to the listener.
+    // We share tracked invoices across all instances of the same lightning address via a static,
+    // address-keyed registry so the listener can poll invoices created by another instance.
+    private static readonly ConcurrentDictionary<string, ConcurrentDictionary<string, TrackedInvoice>>
+        _sharedTracked = new();
+
+    private ConcurrentDictionary<string, TrackedInvoice> _tracked =>
+        _sharedTracked.GetOrAdd(_lightningAddress, _ => new ConcurrentDictionary<string, TrackedInvoice>());
+
+    // The origin (scheme://host[:port]) of the LNURL-pay callback, which is also the host that
+    // serves the LUD-21 verify endpoint (e.g. https://lnurl.blink.sv). It is NOT the lightning
+    // address domain (blink.sv). Cached so a stateless GetInvoice can rebuild the verify URL.
+    private string? _verifyOrigin;
+
+    public BlinkLnAddressLightningClient(string lightningAddress, bool usd, Network network,
+        HttpClient httpClient, ILogger logger)
+    {
+        _lightningAddress = lightningAddress;
+        var parts = lightningAddress.Split('@');
+        if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
+            throw new FormatException($"Invalid Blink lightning address '{lightningAddress}'");
+        _username = parts[0];
+        _domain = parts[1];
+        _usd = usd;
+        _network = network;
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    private Uri LnurlpMetadataUri
+    {
+        get
+        {
+            // USDB uses a "+usd" wallet modifier on the local part (blink-lnurl-server identifier parsing).
+            var localPart = _usd ? $"{_username}+usd" : _username;
+            var scheme = _domain.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
+                         _domain.StartsWith("localhost:", StringComparison.OrdinalIgnoreCase)
+                ? "http"
+                : "https";
+            return new Uri($"{scheme}://{_domain}/.well-known/lnurlp/{Uri.EscapeDataString(localPart)}");
+        }
+    }
+
+    private async Task<JObject> FetchLnurlMetadata(CancellationToken cancellation)
+    {
+        using var resp = await _httpClient.GetAsync(LnurlpMetadataUri, cancellation);
+        var body = await resp.Content.ReadAsStringAsync(cancellation);
+        if (!resp.IsSuccessStatusCode)
+            throw new Exception(
+                $"Blink lightning address '{_lightningAddress}' not found or unavailable (HTTP {(int)resp.StatusCode}).");
+        var json = JObject.Parse(body);
+        if (json["status"]?.Value<string>()?.Equals("ERROR", StringComparison.OrdinalIgnoreCase) == true)
+            throw new Exception(json["reason"]?.Value<string>() ??
+                                $"Blink lightning address '{_lightningAddress}' returned an error.");
+        if (json["tag"]?.Value<string>() != "payRequest")
+            throw new Exception($"'{_lightningAddress}' is not a valid LNURL-pay endpoint.");
+
+        // Cache the callback origin; the LUD-21 verify endpoint lives on the same host.
+        if (json["callback"]?.Value<string>() is { } cb && Uri.TryCreate(cb, UriKind.Absolute, out var cbUri))
+            _verifyOrigin = cbUri.GetLeftPart(UriPartial.Authority);
+
+        return json;
+    }
+
+    /// <summary>
+    /// Returns the origin (scheme://host[:port]) that serves the LUD-21 verify endpoint.
+    /// Cached across calls; derived from the LNURL-pay callback URL when not yet known.
+    /// This is required because a fresh client instance (e.g. the one BTCPay creates for its
+    /// payment listener/poller) has no in-memory state and must reconstruct the verify URL.
+    /// </summary>
+    private async Task<string> GetVerifyOrigin(CancellationToken cancellation)
+    {
+        if (_verifyOrigin is not null)
+            return _verifyOrigin;
+        await FetchLnurlMetadata(cancellation);
+        return _verifyOrigin ?? throw new Exception("Could not determine the Blink LNURL verify endpoint.");
+    }
+
+    public async Task<LightningInvoice> CreateInvoice(LightMoney amount, string description, TimeSpan expiry,
+        CancellationToken cancellation = new())
+    {
+        return await CreateInvoice(new CreateInvoiceParams(amount, description, expiry), cancellation);
+    }
+
+    public async Task<LightningInvoice> CreateInvoice(CreateInvoiceParams createInvoiceRequest,
+        CancellationToken cancellation = new())
+    {
+        var metadata = await FetchLnurlMetadata(cancellation);
+        var callback = metadata["callback"]?.Value<string>();
+        if (string.IsNullOrEmpty(callback))
+            throw new Exception("LNURL-pay response is missing a callback URL.");
+
+        var amountMsat = createInvoiceRequest.Amount.MilliSatoshi;
+        var min = metadata["minSendable"]?.Value<long>() ?? 1;
+        var max = metadata["maxSendable"]?.Value<long>() ?? long.MaxValue;
+        if (amountMsat < min)
+            throw new Exception(
+                $"Amount {amountMsat} msat is below the minimum accepted by this Blink address ({min} msat).");
+        if (amountMsat > max)
+            throw new Exception(
+                $"Amount {amountMsat} msat is above the maximum accepted by this Blink address ({max} msat).");
+
+        var callbackUri = new UriBuilder(callback);
+        var query = new StringBuilder(callbackUri.Query.TrimStart('?'));
+        if (query.Length > 0) query.Append('&');
+        query.Append("amount=").Append(amountMsat);
+        // Pass along a description/comment when the endpoint allows comments (LUD-12).
+        var commentAllowed = metadata["commentAllowed"]?.Value<int>() ?? 0;
+        if (commentAllowed > 0 && !string.IsNullOrEmpty(createInvoiceRequest.Description))
+        {
+            var comment = createInvoiceRequest.Description!;
+            if (comment.Length > commentAllowed) comment = comment.Substring(0, commentAllowed);
+            query.Append("&comment=").Append(Uri.EscapeDataString(comment));
+        }
+        callbackUri.Query = query.ToString();
+
+        using var resp = await _httpClient.GetAsync(callbackUri.Uri, cancellation);
+        var body = await resp.Content.ReadAsStringAsync(cancellation);
+        var json = JObject.Parse(body);
+        if (json["status"]?.Value<string>()?.Equals("ERROR", StringComparison.OrdinalIgnoreCase) == true)
+            throw new Exception(json["reason"]?.Value<string>() ?? "Blink LNURL callback returned an error.");
+
+        var pr = json["pr"]?.Value<string>();
+        if (string.IsNullOrEmpty(pr))
+            throw new Exception("Blink LNURL callback did not return an invoice.");
+
+        var bolt11 = BOLT11PaymentRequest.Parse(pr, _network);
+
+        // Verify the returned invoice matches what we asked for (guards against a malicious server).
+        if (bolt11.MinimumAmount != LightMoney.MilliSatoshis(amountMsat))
+            throw new Exception(
+                $"Blink returned an invoice for {bolt11.MinimumAmount.MilliSatoshi} msat but {amountMsat} msat was requested.");
+        if (createInvoiceRequest.DescriptionHash is { } dh && bolt11.DescriptionHash is { } bh &&
+            dh != bh)
+            throw new Exception("Blink returned an invoice with a mismatched description hash.");
+
+        var paymentHash = bolt11.PaymentHash?.ToString() ?? throw new Exception("Invoice has no payment hash.");
+        var verifyUrl = json["verify"]?.Value<string>();
+        if (!string.IsNullOrEmpty(verifyUrl) && Uri.TryCreate(verifyUrl, UriKind.Absolute, out var vu))
+            _verifyOrigin = vu.GetLeftPart(UriPartial.Authority);
+        verifyUrl ??= BuildVerifyUrl(paymentHash);
+        var expiresAt = bolt11.ExpiryDate;
+
+        _tracked[paymentHash] = new TrackedInvoice(pr, verifyUrl, expiresAt);
+
+        return new LightningInvoice
+        {
+            Id = paymentHash,
+            PaymentHash = paymentHash,
+            BOLT11 = pr,
+            Amount = bolt11.MinimumAmount,
+            Status = LightningInvoiceStatus.Unpaid,
+            ExpiresAt = expiresAt
+        };
+    }
+
+    // LUD-21 verify URLs on blink-lnurl-server are {verifyOrigin}/verify/{paymentHash}, where
+    // verifyOrigin is the host of the LNURL-pay callback (e.g. https://lnurl.blink.sv) - NOT the
+    // lightning address domain. Requires the origin to have already been resolved.
+    private string BuildVerifyUrl(string paymentHash)
+    {
+        if (_verifyOrigin is null)
+            throw new InvalidOperationException("Verify origin not resolved yet.");
+        return $"{_verifyOrigin}/verify/{paymentHash}";
+    }
+
+    public async Task<LightningInvoice?> GetInvoice(string invoiceId, CancellationToken cancellation = new())
+    {
+        _tracked.TryGetValue(invoiceId, out var tracked);
+
+        // Resolve the verify URL statelessly. On a fresh client instance (BTCPay's listener/poller)
+        // there is no tracked invoice, so derive the verify origin from LNURL metadata.
+        string verifyUrl;
+        if (tracked?.VerifyUrl is { } tv)
+            verifyUrl = tv;
+        else
+            verifyUrl = $"{await GetVerifyOrigin(cancellation)}/verify/{invoiceId}";
+
+        JObject? json = null;
+        bool transportError = false;
+        try
+        {
+            using var resp = await _httpClient.GetAsync(verifyUrl, cancellation);
+            var body = await resp.Content.ReadAsStringAsync(cancellation);
+            if (resp.IsSuccessStatusCode)
+                json = JObject.Parse(body);
+            else
+                transportError = true;
+        }
+        catch (Exception e)
+        {
+            transportError = true;
+            _logger.LogDebug(e, "Blink LUD-21 verify request failed for {PaymentHash}", invoiceId);
+        }
+
+        // Explicit "not found" from the verify endpoint => the invoice genuinely does not exist.
+        // Only in that case do we return null (BTCPay will stop tracking it).
+        if (json?["status"]?.Value<string>()?.Equals("ERROR", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            _logger.LogDebug("Blink verify returned ERROR for {PaymentHash}: {Reason}", invoiceId,
+                json["reason"]?.Value<string>());
+            return null;
+        }
+
+        var pr = tracked?.Bolt11 ?? json?["pr"]?.Value<string>();
+        if (pr is null)
+        {
+            // Transient transport error on a fresh client (no cached bolt11). Do NOT return null:
+            // BTCPay's poller drops an invoice from monitoring when GetInvoice returns null, and it
+            // only re-seeds monitored invoices on restart. Instead return a minimal Unpaid invoice so
+            // the invoice stays tracked and is retried. (BTCPay short-circuits Unpaid before reading
+            // amount/bolt11 fields, so this is safe.)
+            if (transportError)
+                return new LightningInvoice
+                {
+                    Id = invoiceId,
+                    PaymentHash = invoiceId,
+                    Status = LightningInvoiceStatus.Unpaid
+                };
+            return null;
+        }
+
+        var settled = json?["settled"]?.Value<bool>() ?? false;
+        var preimage = json?["preimage"]?.Value<string>();
+        var expiresAt = tracked?.ExpiresAt ?? BOLT11PaymentRequest.Parse(pr, _network).ExpiryDate;
+        var t = new TrackedInvoice(pr, verifyUrl, expiresAt);
+        return BuildInvoice(invoiceId, t, settled, preimage);
+    }
+
+    private LightningInvoice BuildInvoice(string paymentHash, TrackedInvoice tracked, bool settled, string? preimage)
+    {
+        var bolt11 = BOLT11PaymentRequest.Parse(tracked.Bolt11, _network);
+        LightningInvoiceStatus status;
+        if (settled) status = LightningInvoiceStatus.Paid;
+        else if (tracked.ExpiresAt < DateTimeOffset.UtcNow) status = LightningInvoiceStatus.Expired;
+        else status = LightningInvoiceStatus.Unpaid;
+
+        // The authoritative payment hash is the verify key (the `paymentHash` argument = BTCPay's
+        // invoice Id), NOT the hash parsed from the returned `pr`. blink-lnurl-server's verify
+        // endpoint has been observed to return a `pr` whose payment hash can differ from the verify
+        // key, so we validate the preimage against `paymentHash`.
+        //
+        // Compare as hex STRINGS to avoid NBitcoin's byte-order pitfalls: new uint256(hexString)
+        // reverses bytes (display order) while new uint256(byte[]) does not, so comparing a
+        // SHA256(byte[]) uint256 against a uint256 parsed from a hex string never matches.
+        var normalizedPaymentHash = paymentHash.Trim().ToLowerInvariant();
+
+        // Only trust the parsed BOLT11 (for BOLT11/Amount) if it actually corresponds to the
+        // authoritative payment hash. Otherwise the `pr` is a mismatched fallback from verify and we
+        // must not report it to BTCPay. The tracked bolt11 (created by us) always matches.
+        bool bolt11Matches = bolt11.PaymentHash?.ToString().Equals(normalizedPaymentHash,
+            StringComparison.OrdinalIgnoreCase) == true;
+        var reportedBolt11 = bolt11Matches ? tracked.Bolt11 : null;
+        var reportedAmount = bolt11Matches ? bolt11.MinimumAmount : null;
+
+        // BTCPay validates the preimage: it must be 64 hex chars and SHA256(preimage)==paymentHash.
+        // If invalid, drop it (the payment is still recorded, just without a preimage).
+        string? validPreimage = null;
+        if (settled && preimage is { Length: 64 } && IsHex(preimage) && normalizedPaymentHash.Length == 64)
+        {
+            try
+            {
+                var preimageBytes = Encoders.Hex.DecodeData(preimage);
+                var computedHex = Encoders.Hex.EncodeData(Hashes.SHA256(preimageBytes));
+                if (computedHex.Equals(normalizedPaymentHash, StringComparison.OrdinalIgnoreCase))
+                    validPreimage = preimage;
+                else
+                    _logger.LogWarning("Blink preimage for {PaymentHash} does not hash to the payment hash (got {Computed}); discarding.", paymentHash, computedHex);
+            }
+            catch (Exception e)
+            {
+                _logger.LogDebug(e, "Failed to validate Blink preimage for {PaymentHash}", paymentHash);
+            }
+        }
+
+        return new LightningInvoice
+        {
+            Id = paymentHash,
+            PaymentHash = paymentHash,
+            BOLT11 = reportedBolt11,
+            // Amount is parsed from the BOLT11; BTCPay requires a non-null amount to record payment.
+            Amount = reportedAmount,
+            AmountReceived = settled ? reportedAmount : null,
+            Status = status,
+            Preimage = validPreimage,
+            PaidAt = settled ? DateTimeOffset.UtcNow : null,
+            ExpiresAt = tracked.ExpiresAt
+        };
+    }
+
+    private static bool IsHex(string s)
+    {
+        foreach (var c in s)
+            if (!Uri.IsHexDigit(c))
+                return false;
+        return true;
+    }
+
+    public async Task<LightningInvoice?> GetInvoice(uint256 paymentHash, CancellationToken cancellation = new())
+    {
+        return await GetInvoice(paymentHash.ToString(), cancellation);
+    }
+
+    public Task<LightningInvoice[]> ListInvoices(CancellationToken cancellation = new())
+    {
+        return ListInvoices(new ListInvoicesParams(), cancellation);
+    }
+
+    public Task<LightningInvoice[]> ListInvoices(ListInvoicesParams request, CancellationToken cancellation = new())
+    {
+        // No server-side invoice list is available for non-custodial accounts; only in-memory tracked invoices.
+        var invoices = _tracked
+            .Select(kv => BuildInvoice(kv.Key, kv.Value, false, null))
+            .Where(i => request.PendingOnly is not true || i.Status == LightningInvoiceStatus.Unpaid)
+            .ToArray();
+        return Task.FromResult(invoices);
+    }
+
+    public async Task<ILightningInvoiceListener> Listen(CancellationToken cancellation = new())
+    {
+        return new BlinkLnAddressListener(this, _logger);
+    }
+
+    /// <summary>
+    /// Polls the LUD-21 verify URLs of tracked, unpaid invoices and yields them as they settle.
+    /// Spark settlement is delivered to blink-lnurl-server via an SSP webhook, so detection may lag
+    /// the actual payment by a few seconds; there is no websocket for non-custodial accounts.
+    /// </summary>
+    public class BlinkLnAddressListener : ILightningInvoiceListener
+    {
+        private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(3);
+        private readonly BlinkLnAddressLightningClient _client;
+        private readonly ILogger _logger;
+        private readonly Channel<LightningInvoice> _channel = Channel.CreateUnbounded<LightningInvoice>();
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _pollTask;
+
+        public BlinkLnAddressListener(BlinkLnAddressLightningClient client, ILogger logger)
+        {
+            _client = client;
+            _logger = logger;
+            _pollTask = Task.Run(() => PollLoop(_cts.Token));
+        }
+
+        private async Task PollLoop(CancellationToken cancellation)
+        {
+            try
+            {
+                while (!cancellation.IsCancellationRequested)
+                {
+                    foreach (var kv in _client._tracked.ToArray())
+                    {
+                        cancellation.ThrowIfCancellationRequested();
+                        var (paymentHash, tracked) = (kv.Key, kv.Value);
+                        try
+                        {
+                            var invoice = await _client.GetInvoice(paymentHash, cancellation);
+                            if (invoice is null) continue;
+                            if (invoice.Status == LightningInvoiceStatus.Paid)
+                            {
+                                _client._tracked.TryRemove(paymentHash, out _);
+                                await _channel.Writer.WriteAsync(invoice, cancellation);
+                            }
+                            else if (invoice.Status == LightningInvoiceStatus.Expired ||
+                                     tracked.ExpiresAt < DateTimeOffset.UtcNow)
+                            {
+                                _client._tracked.TryRemove(paymentHash, out _);
+                            }
+                        }
+                        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+                        {
+                            throw;
+                        }
+                        catch (Exception e)
+                        {
+                            _logger.LogDebug(e, "Error polling Blink invoice {PaymentHash}", paymentHash);
+                        }
+                    }
+
+                    await Task.Delay(PollInterval, cancellation);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception e)
+            {
+                _channel.Writer.TryComplete(e);
+            }
+        }
+
+        public async Task<LightningInvoice> WaitInvoice(CancellationToken cancellation)
+        {
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellation, _cts.Token);
+            return await _channel.Reader.ReadAsync(linked.Token);
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            _channel.Writer.TryComplete();
+            _cts.Dispose();
+        }
+    }
+
+    public async Task<ValidationResult?> Validate()
+    {
+        if (_network != Network.Main)
+            return new ValidationResult(
+                "Blink non-custodial (Spark) accounts are only available on mainnet (blink.sv).");
+        try
+        {
+            var metadata = await FetchLnurlMetadata(CancellationToken.None);
+            if (metadata["callback"]?.Value<string>() is null or "")
+                return new ValidationResult("The Blink lightning address did not return a valid LNURL-pay callback.");
+        }
+        catch (Exception e)
+        {
+            if (_usd)
+                return new ValidationResult(
+                    $"Could not validate the USD (USDB) Blink address. Non-custodial USD receive may not yet be supported by Blink. ({e.Message})");
+            return new ValidationResult(e.Message);
+        }
+
+        return ValidationResult.Success;
+    }
+
+    private const string ReceiveOnlyMessage =
+        "This is a Blink non-custodial (Spark) account configured for receiving only. Sending, balance and channel operations require the wallet seed and are not supported.";
+
+    public Task<PayResponse> Pay(PayInvoiceParams payParams, CancellationToken cancellation = new())
+        => throw new NotSupportedException(ReceiveOnlyMessage);
+
+    public Task<PayResponse> Pay(string bolt11, PayInvoiceParams payParams, CancellationToken cancellation = new())
+        => throw new NotSupportedException(ReceiveOnlyMessage);
+
+    public Task<PayResponse> Pay(string bolt11, CancellationToken cancellation = new())
+        => throw new NotSupportedException(ReceiveOnlyMessage);
+
+    public Task<LightningPayment?> GetPayment(string paymentHash, CancellationToken cancellation = new())
+        => Task.FromResult<LightningPayment?>(null);
+
+    public Task<LightningPayment[]> ListPayments(CancellationToken cancellation = new())
+        => Task.FromResult(Array.Empty<LightningPayment>());
+
+    public Task<LightningPayment[]> ListPayments(ListPaymentsParams request, CancellationToken cancellation = new())
+        => Task.FromResult(Array.Empty<LightningPayment>());
+
+    public Task<LightningNodeInformation> GetInfo(CancellationToken cancellation = new())
+        => throw new NotSupportedException(ReceiveOnlyMessage);
+
+    public Task<LightningNodeBalance> GetBalance(CancellationToken cancellation = new())
+        => throw new NotSupportedException(ReceiveOnlyMessage);
+
+    public Task CancelInvoice(string invoiceId, CancellationToken cancellation = new())
+    {
+        _tracked.TryRemove(invoiceId, out _);
+        return Task.CompletedTask;
+    }
+
+    public Task<BitcoinAddress> GetDepositAddress(CancellationToken cancellation = new())
+        => throw new NotSupportedException(ReceiveOnlyMessage);
+
+    public Task<OpenChannelResponse> OpenChannel(OpenChannelRequest openChannelRequest,
+        CancellationToken cancellation = new())
+        => throw new NotSupportedException(ReceiveOnlyMessage);
+
+    public Task<ConnectionResult> ConnectTo(NodeInfo nodeInfo, CancellationToken cancellation = new())
+        => throw new NotSupportedException(ReceiveOnlyMessage);
+
+    public Task<LightningChannel[]> ListChannels(CancellationToken cancellation = new())
+        => throw new NotSupportedException(ReceiveOnlyMessage);
+
+    public string? DisplayName => "Blink (non-custodial)";
+    public Uri? ServerUri => new($"https://{_domain}");
+}

--- a/Plugins/BTCPayServer.Plugins.Blink/README.md
+++ b/Plugins/BTCPayServer.Plugins.Blink/README.md
@@ -34,6 +34,7 @@ type=blink;ln-address=yourname@blink.sv;
 ```
 
 - A bare username is accepted and defaults to the `blink.sv` domain (`ln-address=yourname`).
+- `username=` is accepted as an alias for `ln-address=` (e.g. `type=blink;username=yourname@blink.sv;`).
 - Only **receiving** is supported. Sending, balance and channel operations are not available because
   they require the wallet seed, which BTCPay never holds.
 - Only **mainnet** (`blink.sv`) is supported for non-custodial accounts.

--- a/Plugins/BTCPayServer.Plugins.Blink/README.md
+++ b/Plugins/BTCPayServer.Plugins.Blink/README.md
@@ -3,3 +3,63 @@
 Allows to use a [Blink Wallet](https://blink.sv) account as the lightning provider for BTCPay Server.
 
 Find detailed documentation on how to use this plugin at [dev.blink.sv/examples/btcpayserver-plugin](https://dev.blink.sv/examples/btcpayserver-plugin).
+
+## Account types
+
+The plugin supports two kinds of Blink accounts, selected by the connection string.
+
+### Custodial account (send + receive)
+
+Uses a Blink API key. Full functionality (create invoices, pay invoices, balance).
+
+```
+type=blink;server=https://api.blink.sv/graphql;api-key=blink_...;wallet-id=xyz;currency=BTC;
+```
+
+- `server` is optional (defaults to the public Blink instance).
+- `wallet-id` is optional (defaults to the account's default wallet).
+- `currency` is optional (`BTC` or `USD`).
+
+Create an API key on the [Blink dashboard](https://dashboard.blink.sv). For BTCPay receiving you
+need at least the `READ` and `RECEIVE` scopes; `WRITE` is additionally required to pay invoices.
+
+### Non-custodial (Spark) account — receive only
+
+The new Blink non-custodial accounts do not expose an API key or a GraphQL wallet id. Receiving is
+brokered through the public LNURL-pay endpoint of your Blink lightning address, and settlement is
+detected via the LNURL LUD-21 `verify` mechanism. No credentials are required.
+
+```
+type=blink;ln-address=yourname@blink.sv;
+```
+
+- A bare username is accepted and defaults to the `blink.sv` domain (`ln-address=yourname`).
+- Only **receiving** is supported. Sending, balance and channel operations are not available because
+  they require the wallet seed, which BTCPay never holds.
+- Only **mainnet** (`blink.sv`) is supported for non-custodial accounts.
+- **USDB (non-custodial Dollar balance):** add `currency=USD`
+  (`type=blink;ln-address=yourname@blink.sv;currency=USD;`). This is passed through so it works
+  automatically once Blink enables non-custodial USD receiving; until then validation will report it
+  as unavailable.
+
+Note: because there is no websocket for non-custodial accounts, payment detection uses polling of the
+LUD-21 verify URL. Settlement typically appears in BTCPay within a few seconds of payment.
+
+## Migration: custodial → non-custodial
+
+If your Blink account is migrated from custodial to non-custodial, the existing BTCPay integration
+that relies on an API key (`api-key=...`) will stop working once the custodial wallet is retired,
+because non-custodial accounts have no API key or GraphQL wallet id.
+
+To keep receiving payments after the migration, update the store's Lightning connection string to the
+non-custodial (receive-only) form:
+
+```
+type=blink;ln-address=yourname@blink.sv;
+```
+
+- **No new API key is required** for receiving — the lightning address of your non-custodial account
+  is sufficient.
+- If you also need to **send** from BTCPay, a non-custodial account cannot do so through the plugin
+  (sending requires the wallet seed). Keep a custodial account/API key for send-side use cases, or use
+  a different Lightning backend for sending.

--- a/Plugins/BTCPayServer.Plugins.Blink/Views/Shared/Blink/LNPaymentMethodSetupTab.cshtml
+++ b/Plugins/BTCPayServer.Plugins.Blink/Views/Shared/Blink/LNPaymentMethodSetupTab.cshtml
@@ -27,12 +27,20 @@
         </h2>
         <div id="CustomBlinkContent" class="accordion-collapse collapse" aria-labelledby="CustomBlinkHeader" data-bs-parent="#CustomNodeSupport">
             <div class="accordion-body">
+                <p class="my-2"><strong>Custodial account</strong> (API key):</p>
                 <ul class="pb-2">
                     <li>
                         <code><b>type=</b>blink;<b>server=</b>https://api.blink.sv/graphql;<b>api-key</b>=blink_...;<b>wallet-id=</b>xyz;<b>currency=</b>BTC;</code>
                     </li>
                 </ul>
                 <p class="my-2">Head over to the <a href="https://dashboard.blink.sv" target="_blank" rel="noreferrer noopener" >Blink dashboard</a> and create an api key. The server is optional and will use the default Blink instance.The wallet-id is optional and will use the default wallet otherwise.</p>
+                <p class="my-2"><strong>Non-custodial (Spark) account</strong> — receive only, no API key:</p>
+                <ul class="pb-2">
+                    <li>
+                        <code><b>type=</b>blink;<b>ln-address=</b>yourname@blink.sv;</code>
+                    </li>
+                </ul>
+                <p class="my-2">Use this for the new non-custodial Blink accounts. It receives payments via your Blink lightning address and detects settlement automatically. Sending, balance and channel operations are not available for non-custodial accounts (they require the wallet seed). Add <code>currency=USD</code> to target the Dollar (USDB) balance once Blink enables non-custodial USD receiving.</p>
             </div>
         </div>
     </div>

--- a/Plugins/BTCPayServer.Plugins.Blink/Views/Shared/Blink/LNPaymentMethodSetupTab.cshtml
+++ b/Plugins/BTCPayServer.Plugins.Blink/Views/Shared/Blink/LNPaymentMethodSetupTab.cshtml
@@ -21,7 +21,7 @@
     <div class="accordion-item">
         <h2 class="accordion-header" id="CustomBlinkHeader">
             <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#CustomBlinkContent" aria-controls="CustomBlinkContent" aria-expanded="false">
-                <span><strong>Blink</strong> via GraphQL</span>
+                <span><strong>Blink</strong> account setup</span>
                 <vc:icon symbol="caret-down"/>
             </button>
         </h2>


### PR DESCRIPTION
## Summary

Blink is migrating users from custodial accounts to non-custodial (Spark) accounts. Non-custodial accounts have **no API key and no GraphQL wallet id**, so the existing custodial Blink client cannot be used with them and existing BTCPay integrations will stop working after migration.

This PR adds **receive-only** support for non-custodial Blink accounts using the account's Blink lightning address.

## How it works

Non-custodial receive is brokered through the public LNURL-pay endpoint (served by `blink-lnurl-server`), with settlement detected via the LUD-21 `verify` URL. No credentials are required.

- Invoices are created via the lightning address's LNURL-pay callback.
- Settlement is detected by polling the LUD-21 verify URL (its host is the LNURL callback origin, e.g. `lnurl.blink.sv`), which returns the preimage once the Spark SSP webhook has settled the invoice.
- The preimage is validated (`SHA256(preimage) == payment hash`) before being reported to BTCPay.
- Tracked invoices are shared across client instances via a static, address-keyed registry, because BTCPay creates a separate `ILightningClient` instance for its payment listener/poller.

## Connection string

```
type=blink;ln-address=yourname@blink.sv;
```

A bare username defaults to the `blink.sv` domain. The existing custodial (`api-key=...`) connection string path is unchanged.

## Scope / limitations

- **Receive only.** Sending, balance and channel operations require the wallet seed and are not supported for non-custodial accounts.
- **Mainnet only** (non-custodial Spark accounts are production-only).
- **USDB:** `currency=USD` is accepted and passed through as a `+usd` wallet modifier for future non-custodial USD receive; it is documented as not yet available server-side.

## Testing

Tested end-to-end on a live BTCPay Server v2.4.0 instance against a real non-custodial account (`twentyone@blink.sv`) on production `blink.sv`:

- Invoice creation via the lightning address ✅
- Payment detection / settlement on the checkout page ✅
- Preimage validated and stored as proof-of-payment ✅
- Existing custodial (api-key) connection strings unaffected ✅

## Context

This addresses a real migration question from an integrator: after moving to a non-custodial account, merchants reconnect BTCPay with `type=blink;ln-address=...` and **no new API key is required for receiving**. See the updated plugin README for a migration section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added non-custodial Spark account support using `ln-address` (receive-only) without requiring an API key.
  * Support includes invoice creation and settlement/payout status polling via public LNURL/LUD-21 endpoints.
  * Optional `currency=USD` support for Spark receiving.

* **Documentation**
  * Updated setup UI and README to clearly separate custodial (API key) vs. non-custodial (receive-only) configurations, including migration guidance and examples.

* **Chores**
  * Bumped the Blink plugin version to `1.1.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->