### PR TITLE
Blink: unit tests for payment status hooks + pure logic

### DIFF
--- a/BTCPayServer.Plugins.Blink.Tests/BTCPayServer.Plugins.Blink.Tests.csproj
+++ b/BTCPayServer.Plugins.Blink.Tests/BTCPayServer.Plugins.Blink.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <!-- Lightweight unit-test project for the Blink plugin's pure logic
+         (payment/invoice status mappings, LNURL address/URI parsing, preimage
+         validation, amount bounds, back-off math, connection-string routing).
+         References ONLY the Blink plugin + BTCPayServer runtime - NOT
+         BTCPayServer.Tests / ServerTester - so it builds and runs in seconds. -->
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageReference Include="xunit.v3" Version="3.2.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Plugins\BTCPayServer.Plugins.Blink\BTCPayServer.Plugins.Blink.csproj" />
+        <ProjectReference Include="..\submodules\btcpayserver\BTCPayServer\BTCPayServer.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/BTCPayServer.Plugins.Blink.Tests/BlinkConnectionStringRoutingTests.cs
+++ b/BTCPayServer.Plugins.Blink.Tests/BlinkConnectionStringRoutingTests.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using BTCPayServer.Plugins.Blink;
+using NBitcoin;
+using Xunit;
+
+// Tests for the connection-string handler's pure routing decisions: whether a blink connection
+// string is treated as a non-custodial (ln-address) account, and the default server per network.
+public class BlinkConnectionStringRoutingTests
+{
+    private static Dictionary<string, string> Kv(params (string Key, string Value)[] pairs)
+    {
+        var d = new Dictionary<string, string>();
+        foreach (var (k, v) in pairs) d[k] = v;
+        return d;
+    }
+
+    [Fact]
+    public void LnAddress_routes_non_custodial()
+    {
+        var ok = BlinkLightningConnectionStringHandler.IsLnAddressConnectionString(
+            Kv(("ln-address", "twentyone@blink.sv")), out var lnAddress);
+        Assert.True(ok);
+        Assert.Equal("twentyone@blink.sv", lnAddress);
+    }
+
+    [Fact]
+    public void Username_alias_routes_non_custodial()
+    {
+        var ok = BlinkLightningConnectionStringHandler.IsLnAddressConnectionString(
+            Kv(("username", "twentyone@blink.sv")), out var lnAddress);
+        Assert.True(ok);
+        Assert.Equal("twentyone@blink.sv", lnAddress);
+    }
+
+    [Fact]
+    public void ApiKey_present_is_custodial_even_with_ln_address()
+    {
+        // An api-key takes precedence: this is a custodial connection, not routed to the ln-address client.
+        var ok = BlinkLightningConnectionStringHandler.IsLnAddressConnectionString(
+            Kv(("api-key", "blink_abc"), ("ln-address", "twentyone@blink.sv")), out var lnAddress);
+        Assert.False(ok);
+        Assert.Null(lnAddress);
+    }
+
+    [Fact]
+    public void ApiKey_only_is_custodial()
+    {
+        var ok = BlinkLightningConnectionStringHandler.IsLnAddressConnectionString(
+            Kv(("api-key", "blink_abc"), ("wallet-id", "xyz")), out var lnAddress);
+        Assert.False(ok);
+        Assert.Null(lnAddress);
+    }
+
+    [Fact]
+    public void Neither_key_is_not_ln_address()
+    {
+        var ok = BlinkLightningConnectionStringHandler.IsLnAddressConnectionString(
+            Kv(("server", "https://api.blink.sv/graphql")), out var lnAddress);
+        Assert.False(ok);
+        Assert.Null(lnAddress);
+    }
+
+    [Fact]
+    public void DefaultServer_mainnet()
+    {
+        Assert.Equal("https://api.blink.sv/graphql", BlinkLightningConnectionStringHandler.DefaultServer(Network.Main));
+    }
+
+    [Fact]
+    public void DefaultServer_testnet()
+    {
+        Assert.Equal("https://api.staging.galoy.io/graphql",
+            BlinkLightningConnectionStringHandler.DefaultServer(Network.TestNet));
+    }
+
+    [Fact]
+    public void DefaultServer_regtest()
+    {
+        Assert.Equal("http://localhost:4455/graphql",
+            BlinkLightningConnectionStringHandler.DefaultServer(Network.RegTest));
+    }
+}

--- a/BTCPayServer.Plugins.Blink.Tests/BlinkLnAddressLogicTests.cs
+++ b/BTCPayServer.Plugins.Blink.Tests/BlinkLnAddressLogicTests.cs
@@ -102,6 +102,16 @@ public class BlinkLnAddressLogicTests
             BlinkLnAddressLightningClient.DetermineStatus(false, now.AddMinutes(10), now));
     }
 
+    [Fact]
+    public void DetermineStatus_unpaid_when_expiry_equals_now()
+    {
+        // Expiry is strictly-less-than (expiresAt < now => Expired), so an invoice whose expiry equals
+        // 'now' is still Unpaid. Pins this intentional tie-break to avoid a 1-tick premature expiry.
+        var now = DateTimeOffset.UtcNow;
+        Assert.Equal(LightningInvoiceStatus.Unpaid,
+            BlinkLnAddressLightningClient.DetermineStatus(false, now, now));
+    }
+
     // ---- Back-off math ----
 
     [Fact]
@@ -197,6 +207,11 @@ public class BlinkLnAddressLogicTests
     [InlineData("")]
     [InlineData("not a url")]
     [InlineData("/relative/path")]
+    // Non-http(s) absolute URLs must be rejected by the scheme guard (they would otherwise pass the
+    // Uri.TryCreate gate). This locks in the http/https-only behavior of ExtractOrigin.
+    [InlineData("ftp://example.com")]
+    [InlineData("file:///etc/passwd")]
+    [InlineData("ws://lnurl.blink.sv/lnurlp/foo")]
     public void ExtractOrigin_returns_null_for_invalid(string? url)
     {
         Assert.Null(BlinkLnAddressLightningClient.ExtractOrigin(url));
@@ -211,14 +226,30 @@ public class BlinkLnAddressLogicTests
     }
 
     [Fact]
+    public void ValidateAmountBounds_passes_at_exact_min()
+    {
+        // The bound is exclusive-below (amountMsat < min throws), so amount == min is accepted.
+        BlinkLnAddressLightningClient.ValidateAmountBounds(1_000, 1_000, 1_000_000);
+    }
+
+    [Fact]
+    public void ValidateAmountBounds_passes_at_exact_max()
+    {
+        // The bound is exclusive-above (amountMsat > max throws), so amount == max is accepted.
+        BlinkLnAddressLightningClient.ValidateAmountBounds(1_000_000, 1_000, 1_000_000);
+    }
+
+    [Fact]
     public void ValidateAmountBounds_throws_below_min()
     {
-        Assert.Throws<Exception>(() => BlinkLnAddressLightningClient.ValidateAmountBounds(500, 1_000, 1_000_000));
+        var ex = Assert.Throws<Exception>(() => BlinkLnAddressLightningClient.ValidateAmountBounds(500, 1_000, 1_000_000));
+        Assert.Contains("below", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
     public void ValidateAmountBounds_throws_above_max()
     {
-        Assert.Throws<Exception>(() => BlinkLnAddressLightningClient.ValidateAmountBounds(2_000_000, 1_000, 1_000_000));
+        var ex = Assert.Throws<Exception>(() => BlinkLnAddressLightningClient.ValidateAmountBounds(2_000_000, 1_000, 1_000_000));
+        Assert.Contains("above", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/BTCPayServer.Plugins.Blink.Tests/BlinkLnAddressLogicTests.cs
+++ b/BTCPayServer.Plugins.Blink.Tests/BlinkLnAddressLogicTests.cs
@@ -1,0 +1,224 @@
+using System;
+using BTCPayServer.Lightning;
+using BTCPayServer.Plugins.Blink;
+using NBitcoin;
+using NBitcoin.Crypto;
+using NBitcoin.DataEncoders;
+using Xunit;
+
+// Tests for the non-custodial (Spark / LNURL) client's pure logic: LUD-21 preimage validation,
+// invoice status decision, back-off math, lightning-address parsing, LNURL metadata URL building,
+// verify-URL construction, origin extraction, and amount-bounds checks.
+public class BlinkLnAddressLogicTests
+{
+    // A real Blink transaction fixture (from BlinkLightningClient.cs comments): this preimage's
+    // SHA256 equals this payment hash (verified).
+    private const string ValidPreimage = "9d726f2530323bc54c8540481ff9ef20fca22f9da9c39b883a81449aa09ecedd";
+    private const string ValidPaymentHash = "de3073bc40acbbf2948259b7c56212c1e23f030cd113b489aa4805ba46a772bb";
+
+    // ---- Preimage validation ----
+
+    [Fact]
+    public void ValidatePreimage_accepts_matching_preimage()
+    {
+        Assert.Equal(ValidPreimage, BlinkLnAddressLightningClient.ValidatePreimage(ValidPaymentHash, ValidPreimage));
+    }
+
+    [Fact]
+    public void ValidatePreimage_is_case_insensitive_on_hash()
+    {
+        Assert.Equal(ValidPreimage,
+            BlinkLnAddressLightningClient.ValidatePreimage(ValidPaymentHash.ToUpperInvariant(), ValidPreimage));
+    }
+
+    [Fact]
+    public void ValidatePreimage_rejects_wrong_preimage()
+    {
+        var wrong = new string('a', 64);
+        Assert.Null(BlinkLnAddressLightningClient.ValidatePreimage(ValidPaymentHash, wrong));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("tooshort")]
+    [InlineData("zzzz6f2530323bc54c8540481ff9ef20fca22f9da9c39b883a81449aa09ecedd")] // 64 chars but non-hex
+    public void ValidatePreimage_rejects_malformed(string? preimage)
+    {
+        Assert.Null(BlinkLnAddressLightningClient.ValidatePreimage(ValidPaymentHash, preimage));
+    }
+
+    [Fact]
+    public void ValidatePreimage_rejects_when_payment_hash_not_64_hex()
+    {
+        Assert.Null(BlinkLnAddressLightningClient.ValidatePreimage("nothex", ValidPreimage));
+    }
+
+    [Fact]
+    public void ValidatePreimage_roundtrips_a_generated_pair()
+    {
+        var preimageBytes = RandomUtils.GetBytes(32);
+        var preimage = Encoders.Hex.EncodeData(preimageBytes);
+        var paymentHash = Encoders.Hex.EncodeData(Hashes.SHA256(preimageBytes));
+        Assert.Equal(preimage, BlinkLnAddressLightningClient.ValidatePreimage(paymentHash, preimage));
+    }
+
+    // ---- IsHex ----
+
+    [Theory]
+    [InlineData("deadbeef", true)]
+    [InlineData("DEADBEEF", true)]
+    [InlineData("0123456789abcdefABCDEF", true)]
+    [InlineData("xyz", false)]
+    [InlineData("dead beef", false)]
+    public void IsHex_detects_hex(string input, bool expected)
+    {
+        Assert.Equal(expected, BlinkLnAddressLightningClient.IsHex(input));
+    }
+
+    // ---- Invoice status decision ----
+
+    [Fact]
+    public void DetermineStatus_paid_when_settled()
+    {
+        var now = DateTimeOffset.UtcNow;
+        Assert.Equal(LightningInvoiceStatus.Paid,
+            BlinkLnAddressLightningClient.DetermineStatus(true, now.AddMinutes(-10), now));
+    }
+
+    [Fact]
+    public void DetermineStatus_expired_when_unsettled_and_past_expiry()
+    {
+        var now = DateTimeOffset.UtcNow;
+        Assert.Equal(LightningInvoiceStatus.Expired,
+            BlinkLnAddressLightningClient.DetermineStatus(false, now.AddSeconds(-1), now));
+    }
+
+    [Fact]
+    public void DetermineStatus_unpaid_when_unsettled_and_not_expired()
+    {
+        var now = DateTimeOffset.UtcNow;
+        Assert.Equal(LightningInvoiceStatus.Unpaid,
+            BlinkLnAddressLightningClient.DetermineStatus(false, now.AddMinutes(10), now));
+    }
+
+    // ---- Back-off math ----
+
+    [Fact]
+    public void NextBackoff_grows_exponentially_from_poll_interval()
+    {
+        var poll = TimeSpan.FromSeconds(3);
+        var max = TimeSpan.FromSeconds(30);
+
+        var (e1, d1) = BlinkLnAddressLightningClient.NextBackoff(0, poll, max);
+        Assert.Equal(1, e1);
+        Assert.Equal(TimeSpan.FromSeconds(6), d1); // 3 * 2^1
+
+        var (e2, d2) = BlinkLnAddressLightningClient.NextBackoff(1, poll, max);
+        Assert.Equal(2, e2);
+        Assert.Equal(TimeSpan.FromSeconds(12), d2); // 3 * 2^2
+    }
+
+    [Fact]
+    public void NextBackoff_caps_at_max()
+    {
+        var poll = TimeSpan.FromSeconds(3);
+        var max = TimeSpan.FromSeconds(30);
+        var (errors, delay) = BlinkLnAddressLightningClient.NextBackoff(10, poll, max);
+        Assert.Equal(11, errors);
+        Assert.Equal(max, delay);
+    }
+
+    // ---- Lightning-address parsing ----
+
+    [Fact]
+    public void ParseLightningAddress_splits_user_and_domain()
+    {
+        var (user, domain) = BlinkLnAddressLightningClient.ParseLightningAddress("twentyone@blink.sv");
+        Assert.Equal("twentyone", user);
+        Assert.Equal("blink.sv", domain);
+    }
+
+    [Theory]
+    [InlineData("noatsign")]
+    [InlineData("@blink.sv")]
+    [InlineData("user@")]
+    [InlineData("a@b@c")]
+    [InlineData("")]
+    public void ParseLightningAddress_throws_on_invalid(string address)
+    {
+        Assert.Throws<FormatException>(() => BlinkLnAddressLightningClient.ParseLightningAddress(address));
+    }
+
+    // ---- LNURL metadata URL ----
+
+    [Fact]
+    public void BuildLnurlpMetadataUri_builds_https_for_normal_domain()
+    {
+        var uri = BlinkLnAddressLightningClient.BuildLnurlpMetadataUri("twentyone", "blink.sv", usd: false);
+        Assert.Equal("https://blink.sv/.well-known/lnurlp/twentyone", uri.ToString());
+    }
+
+    [Fact]
+    public void BuildLnurlpMetadataUri_appends_usd_modifier()
+    {
+        var uri = BlinkLnAddressLightningClient.BuildLnurlpMetadataUri("twentyone", "blink.sv", usd: true);
+        // '+' is URL-escaped to %2B in the path segment.
+        Assert.Equal("https://blink.sv/.well-known/lnurlp/twentyone%2Busd", uri.ToString());
+    }
+
+    [Theory]
+    [InlineData("localhost")]
+    [InlineData("localhost:8080")]
+    public void BuildLnurlpMetadataUri_uses_http_for_localhost(string domain)
+    {
+        var uri = BlinkLnAddressLightningClient.BuildLnurlpMetadataUri("u", domain, usd: false);
+        Assert.Equal("http", uri.Scheme);
+    }
+
+    // ---- Verify URL + origin ----
+
+    [Fact]
+    public void BuildVerifyUrl_composes_origin_and_hash()
+    {
+        Assert.Equal("https://lnurl.blink.sv/verify/abcd",
+            BlinkLnAddressLightningClient.BuildVerifyUrl("https://lnurl.blink.sv", "abcd"));
+    }
+
+    [Fact]
+    public void ExtractOrigin_returns_scheme_and_authority()
+    {
+        Assert.Equal("https://lnurl.blink.sv",
+            BlinkLnAddressLightningClient.ExtractOrigin("https://lnurl.blink.sv/lnurlp/blink.sv/twentyone/invoice"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not a url")]
+    [InlineData("/relative/path")]
+    public void ExtractOrigin_returns_null_for_invalid(string? url)
+    {
+        Assert.Null(BlinkLnAddressLightningClient.ExtractOrigin(url));
+    }
+
+    // ---- Amount bounds ----
+
+    [Fact]
+    public void ValidateAmountBounds_passes_within_range()
+    {
+        BlinkLnAddressLightningClient.ValidateAmountBounds(210_000, 1_000, 1_000_000);
+    }
+
+    [Fact]
+    public void ValidateAmountBounds_throws_below_min()
+    {
+        Assert.Throws<Exception>(() => BlinkLnAddressLightningClient.ValidateAmountBounds(500, 1_000, 1_000_000));
+    }
+
+    [Fact]
+    public void ValidateAmountBounds_throws_above_max()
+    {
+        Assert.Throws<Exception>(() => BlinkLnAddressLightningClient.ValidateAmountBounds(2_000_000, 1_000, 1_000_000));
+    }
+}

--- a/BTCPayServer.Plugins.Blink.Tests/BlinkStatusMappingTests.cs
+++ b/BTCPayServer.Plugins.Blink.Tests/BlinkStatusMappingTests.cs
@@ -56,21 +56,14 @@ public class BlinkStatusMappingTests
     }
 
     [Theory]
-    [InlineData("mainnet")]
-    [InlineData("testnet")]
-    [InlineData("signet")]
-    [InlineData("regtest")]
-    public void MapNetwork_maps_known_networks(string network)
+    [InlineData("mainnet", "Main")]
+    [InlineData("testnet", "TestNet")]
+    // signet maps to TestNet (BTCPay has no distinct signet network here).
+    [InlineData("signet", "TestNet")]
+    [InlineData("regtest", "RegTest")]
+    public void MapNetwork_maps_known_networks(string network, string expected)
     {
-        var mapped = BlinkLightningClient.MapNetwork(network);
-        Assert.NotNull(mapped);
-        // signet maps to TestNet (BTCPay has no distinct signet network here).
-        if (network is "signet" or "testnet")
-            Assert.Equal(Network.TestNet, mapped);
-        if (network == "mainnet")
-            Assert.Equal(Network.Main, mapped);
-        if (network == "regtest")
-            Assert.Equal(Network.RegTest, mapped);
+        Assert.Equal(Network.GetNetwork(expected), BlinkLightningClient.MapNetwork(network));
     }
 
     [Fact]

--- a/BTCPayServer.Plugins.Blink.Tests/BlinkStatusMappingTests.cs
+++ b/BTCPayServer.Plugins.Blink.Tests/BlinkStatusMappingTests.cs
@@ -1,0 +1,95 @@
+using BTCPayServer.Lightning;
+using BTCPayServer.Plugins.Blink;
+using NBitcoin;
+using Xunit;
+
+// Tests for the custodial client's "payment status hooks": the mappings from Blink's GraphQL
+// string statuses to BTCPay's invoice/payment/pay enums. These previously threw on unexpected
+// input; the mappers now degrade unknown values safely.
+public class BlinkStatusMappingTests
+{
+    [Theory]
+    [InlineData("PAID", LightningInvoiceStatus.Paid)]
+    [InlineData("EXPIRED", LightningInvoiceStatus.Expired)]
+    [InlineData("PENDING", LightningInvoiceStatus.Unpaid)]
+    [InlineData("SOMETHING_NEW", LightningInvoiceStatus.Unpaid)]
+    [InlineData("", LightningInvoiceStatus.Unpaid)]
+    [InlineData(null, LightningInvoiceStatus.Unpaid)]
+    public void MapInvoiceStatus_maps_and_degrades_unknown_to_unpaid(string? status, LightningInvoiceStatus expected)
+    {
+        Assert.Equal(expected, BlinkLightningClient.MapInvoiceStatus(status));
+    }
+
+    [Theory]
+    [InlineData("SUCCESS", LightningPaymentStatus.Complete)]
+    [InlineData("FAILURE", LightningPaymentStatus.Failed)]
+    [InlineData("PENDING", LightningPaymentStatus.Pending)]
+    [InlineData("WAT", LightningPaymentStatus.Unknown)]
+    [InlineData(null, LightningPaymentStatus.Unknown)]
+    public void MapPaymentStatus_maps_and_degrades_unknown_to_unknown(string? status, LightningPaymentStatus expected)
+    {
+        Assert.Equal(expected, BlinkLightningClient.MapPaymentStatus(status));
+    }
+
+    [Theory]
+    [InlineData("ALREADY_PAID", PayResult.Ok)]
+    [InlineData("SUCCESS", PayResult.Ok)]
+    [InlineData("FAILURE", PayResult.Error)]
+    [InlineData("PENDING", PayResult.Unknown)]
+    [InlineData("WAT", PayResult.Unknown)]
+    [InlineData(null, PayResult.Unknown)]
+    public void MapPayResult_maps_and_degrades_unknown_to_unknown(string? status, PayResult expected)
+    {
+        Assert.Equal(expected, BlinkLightningClient.MapPayResult(status));
+    }
+
+    [Theory]
+    [InlineData("ALREADY_PAID", LightningPaymentStatus.Complete)]
+    [InlineData("SUCCESS", LightningPaymentStatus.Complete)]
+    [InlineData("FAILURE", LightningPaymentStatus.Failed)]
+    [InlineData("PENDING", LightningPaymentStatus.Pending)]
+    [InlineData("WAT", LightningPaymentStatus.Unknown)]
+    [InlineData(null, LightningPaymentStatus.Unknown)]
+    public void MapPayDetailStatus_maps_and_degrades_unknown_to_unknown(string? status, LightningPaymentStatus expected)
+    {
+        Assert.Equal(expected, BlinkLightningClient.MapPayDetailStatus(status));
+    }
+
+    [Theory]
+    [InlineData("mainnet")]
+    [InlineData("testnet")]
+    [InlineData("signet")]
+    [InlineData("regtest")]
+    public void MapNetwork_maps_known_networks(string network)
+    {
+        var mapped = BlinkLightningClient.MapNetwork(network);
+        Assert.NotNull(mapped);
+        // signet maps to TestNet (BTCPay has no distinct signet network here).
+        if (network is "signet" or "testnet")
+            Assert.Equal(Network.TestNet, mapped);
+        if (network == "mainnet")
+            Assert.Equal(Network.Main, mapped);
+        if (network == "regtest")
+            Assert.Equal(Network.RegTest, mapped);
+    }
+
+    [Fact]
+    public void MapNetwork_throws_on_unknown()
+    {
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => BlinkLightningClient.MapNetwork("dogecoin"));
+    }
+
+    [Theory]
+    [InlineData("BTC", BlinkCurrency.BTC)]
+    [InlineData("USD", BlinkCurrency.USD)]
+    public void ParseBlinkCurrency_maps_known(string input, BlinkCurrency expected)
+    {
+        Assert.Equal(expected, BlinkLightningClient.ParseBlinkCurrency(input));
+    }
+
+    [Fact]
+    public void ParseBlinkCurrency_throws_on_unknown()
+    {
+        Assert.Throws<System.FormatException>(() => BlinkLightningClient.ParseBlinkCurrency("EUR"));
+    }
+}

--- a/Plugins/BTCPayServer.Plugins.Blink/BTCPayServer.Plugins.Blink.csproj
+++ b/Plugins/BTCPayServer.Plugins.Blink/BTCPayServer.Plugins.Blink.csproj
@@ -44,5 +44,12 @@
       <PackageReference Include="GraphQL.Client" Version="6.0.2" />
       <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="6.0.2" />
     </ItemGroup>
+
+    <!-- Expose internal static helpers (status mappings, LNURL/preimage/back-off logic) to the unit-test project. -->
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+        <_Parameter1>BTCPayServer.Plugins.Blink.Tests</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
 </Project>
 

--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningClient.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningClient.cs
@@ -246,13 +246,16 @@ query InvoiceByPaymentHash($paymentHash: PaymentHash!, $walletId: WalletId!) {
     public LightningInvoice? ToInvoice(JObject invoice)
     {
         var bolt11 = BOLT11PaymentRequest.Parse(invoice["paymentRequest"].Value<string>(), _network);
+        // Map the status once (null-safe) and reuse it for both Status and PaidAt, so a missing
+        // paymentStatus cannot abort conversion via an unsafe dereference.
+        var status = MapInvoiceStatus(invoice["paymentStatus"]?.Value<string>());
         return new LightningInvoice()
         {
             Id = invoice["paymentHash"].Value<string>(),
             Amount = invoice["satoshis"] is null? bolt11.MinimumAmount:  LightMoney.Satoshis(invoice["satoshis"].Value<long>()),
                 Preimage =  invoice["paymentSecret"].Value<string>(),
-            PaidAt = (invoice["paymentStatus"].Value<string>()) ==  "PAID"? DateTimeOffset.UtcNow : null,
-            Status =  MapInvoiceStatus(invoice["paymentStatus"]?.Value<string>()),
+            PaidAt = status == LightningInvoiceStatus.Paid ? DateTimeOffset.UtcNow : null,
+            Status =  status,
             BOLT11 =  invoice["paymentRequest"].Value<string>(),
             PaymentHash = invoice["paymentHash"].Value<string>(),
             ExpiresAt = bolt11.ExpiryDate

--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningClient.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningClient.cs
@@ -68,6 +68,65 @@ query InvoiceByPaymentHash($walletId: WalletId!) {
             _ => throw new FormatException("Invalid Blink Wallet Currency (Only BTC and USD are supported)")
         };
 
+    /// <summary>Maps a Blink invoice <c>paymentStatus</c> to a BTCPay <see cref="LightningInvoiceStatus"/>.
+    /// Unknown or null values degrade to <see cref="LightningInvoiceStatus.Unpaid"/> so an unexpected
+    /// status from Blink cannot throw and abort payment processing.</summary>
+    internal static LightningInvoiceStatus MapInvoiceStatus(string? paymentStatus)
+        => paymentStatus switch
+        {
+            "EXPIRED" => LightningInvoiceStatus.Expired,
+            "PAID" => LightningInvoiceStatus.Paid,
+            "PENDING" => LightningInvoiceStatus.Unpaid,
+            _ => LightningInvoiceStatus.Unpaid
+        };
+
+    /// <summary>Maps a Blink transaction <c>status</c> to a BTCPay <see cref="LightningPaymentStatus"/>.</summary>
+    internal static LightningPaymentStatus MapPaymentStatus(string? status)
+        => status switch
+        {
+            "FAILURE" => LightningPaymentStatus.Failed,
+            "PENDING" => LightningPaymentStatus.Pending,
+            "SUCCESS" => LightningPaymentStatus.Complete,
+            _ => LightningPaymentStatus.Unknown
+        };
+
+    /// <summary>Maps a Blink <c>lnInvoicePaymentSend.status</c> to a BTCPay <see cref="PayResult"/>.
+    /// Unknown or null values degrade to <see cref="PayResult.Unknown"/>.</summary>
+    internal static PayResult MapPayResult(string? status)
+        => status switch
+        {
+            "ALREADY_PAID" => PayResult.Ok,
+            "SUCCESS" => PayResult.Ok,
+            "FAILURE" => PayResult.Error,
+            "PENDING" => PayResult.Unknown,
+            _ => PayResult.Unknown
+        };
+
+    /// <summary>Maps a Blink payment-send <c>status</c> to a BTCPay <see cref="LightningPaymentStatus"/>
+    /// for the <see cref="PayDetails"/>. Unknown or null values degrade to
+    /// <see cref="LightningPaymentStatus.Unknown"/>.</summary>
+    internal static LightningPaymentStatus MapPayDetailStatus(string? status)
+        => status switch
+        {
+            "ALREADY_PAID" => LightningPaymentStatus.Complete,
+            "SUCCESS" => LightningPaymentStatus.Complete,
+            "FAILURE" => LightningPaymentStatus.Failed,
+            "PENDING" => LightningPaymentStatus.Pending,
+            _ => LightningPaymentStatus.Unknown
+        };
+
+    /// <summary>Maps a Blink <c>globals.network</c> string to an <see cref="NBitcoin.Network"/>.
+    /// Blink signet maps to TestNet (BTCPay has no distinct signet network here).</summary>
+    internal static Network MapNetwork(string network)
+        => network switch
+        {
+            "mainnet" => Network.Main,
+            "testnet" => Network.TestNet,
+            "signet" => Network.TestNet,
+            "regtest" => Network.RegTest,
+            _ => throw new ArgumentOutOfRangeException(nameof(network), network, "Unknown Blink network")
+        };
+
     record WalletInfo(BlinkCurrency WalletCurrency, string WalletId);
 
     private WalletInfo? _WalletInfo;
@@ -193,12 +252,7 @@ query InvoiceByPaymentHash($paymentHash: PaymentHash!, $walletId: WalletId!) {
             Amount = invoice["satoshis"] is null? bolt11.MinimumAmount:  LightMoney.Satoshis(invoice["satoshis"].Value<long>()),
                 Preimage =  invoice["paymentSecret"].Value<string>(),
             PaidAt = (invoice["paymentStatus"].Value<string>()) ==  "PAID"? DateTimeOffset.UtcNow : null,
-            Status =  (invoice["paymentStatus"].Value<string>()) switch
-            {
-                "EXPIRED" => LightningInvoiceStatus.Expired,
-                "PAID" => LightningInvoiceStatus.Paid,
-                "PENDING" => LightningInvoiceStatus.Unpaid
-            },
+            Status =  MapInvoiceStatus(invoice["paymentStatus"]?.Value<string>()),
             BOLT11 =  invoice["paymentRequest"].Value<string>(),
             PaymentHash = invoice["paymentHash"].Value<string>(),
             ExpiresAt = bolt11.ExpiryDate
@@ -351,13 +405,7 @@ query TransactionsByPaymentHash($paymentHash: PaymentHash!, $walletId: WalletId!
         return new LightningPayment()
         {
             Amount = bolt11.MinimumAmount,
-            Status = transaction["status"].ToString() switch
-            {
-                "FAILURE" => LightningPaymentStatus.Failed,
-                "PENDING" => LightningPaymentStatus.Pending,
-                "SUCCESS" => LightningPaymentStatus.Complete,
-                _ => LightningPaymentStatus.Unknown
-            },
+            Status = MapPaymentStatus(transaction["status"]?.ToString()),
             BOLT11 = (string)initiationVia["paymentRequest"],
             Id = (string)initiationVia["paymentHash"],
             PaymentHash = (string)initiationVia["paymentHash"],
@@ -621,14 +669,7 @@ query GetNetworkAndDefaultWallet {
 
         var defaultWalletId = (string) response.Data.me.defaultAccount.defaultWallet.id;
         var defaultWalletCurrency = (string) response.Data.me.defaultAccount.defaultWallet.currency;
-        var network = response.Data.globals.network.ToString() switch
-        {
-            "mainnet" => Network.Main,
-            "testnet" => Network.TestNet,
-            "signet" => Network.TestNet,
-            "regtest" => Network.RegTest,
-            _ => throw new ArgumentOutOfRangeException()
-        };
+        var network = MapNetwork(response.Data.globals.network.ToString());
         return (network, defaultWalletId, ParseBlinkCurrency(defaultWalletCurrency));
     }
 
@@ -741,15 +782,7 @@ mutation LnInvoicePaymentSend($input: LnInvoicePaymentInput!) {
         var response =(JObject) (await  _client.SendQueryAsync<dynamic>(request,  cts.Token)).Data.lnInvoicePaymentSend;
         
         var result = new PayResponse();
-        result.Result = response["status"].Value<string>() switch
-        {
-            "ALREADY_PAID" => PayResult.Ok,
-            "FAILURE" => PayResult.Error,
-            "PENDING"=> PayResult.Unknown,
-            "SUCCESS" => PayResult.Ok,
-            null => PayResult.Unknown,
-            _ => throw new ArgumentOutOfRangeException()
-        };
+        result.Result = MapPayResult(response["status"]?.Value<string>());
         bool authError = false;
         response.TryGetValue("errors", out var error);
         if (result.Result == PayResult.Unknown && error is not null)
@@ -777,15 +810,7 @@ mutation LnInvoicePaymentSend($input: LnInvoicePaymentInput!) {
             result.Details = new PayDetails()
             {
                 PaymentHash = bolt11Parsed.PaymentHash ?? new uint256(response["transaction"]["initiationVia"]["paymentHash"].Value<string>()),
-                Status = response["status"].Value<string>() switch
-                {
-                    "ALREADY_PAID"  => LightningPaymentStatus.Complete,
-                    "FAILURE" => LightningPaymentStatus.Failed,
-                    "PENDING" => LightningPaymentStatus.Pending,
-                    "SUCCESS" => LightningPaymentStatus.Complete,
-                    string status => throw new ArgumentOutOfRangeException($"Unknown status received by blink ({status})"),
-                    _ => LightningPaymentStatus.Unknown,
-                },
+                Status = MapPayDetailStatus(response["status"]?.Value<string>()),
                 Preimage = response["transaction"]["settlementVia"]?["preImage"].Value<string>() is null? null: new uint256(response["transaction"]["settlementVia"]["preImage"].Value<string>()),
             };
         }

--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningConnectionStringHandler.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningConnectionStringHandler.cs
@@ -20,6 +20,25 @@ public class BlinkLightningConnectionStringHandler : ILightningConnectionStringH
         _loggerFactory = loggerFactory;
     }
 
+    /// <summary>Returns the default Blink GraphQL server for the given network when none is specified.</summary>
+    internal static string DefaultServer(Network network)
+        => network.Name switch
+        {
+            nameof(Network.TestNet) => "https://api.staging.galoy.io/graphql",
+            nameof(Network.RegTest) => "http://localhost:4455/graphql",
+            _ => "https://api.blink.sv/graphql"
+        };
+
+    /// <summary>A blink connection string denotes a non-custodial (receive-only) account when it has
+    /// no <c>api-key</c> and carries an <c>ln-address</c> (or its <c>username</c> alias).</summary>
+    internal static bool IsLnAddressConnectionString(
+        System.Collections.Generic.Dictionary<string, string> kv, out string? lnAddress)
+    {
+        lnAddress = null;
+        if (kv.ContainsKey("api-key"))
+            return false;
+        return kv.TryGetValue("ln-address", out lnAddress) || kv.TryGetValue("username", out lnAddress);
+    }
 
     public ILightningClient? Create(string connectionString, Network network, out string? error)
     {
@@ -33,20 +52,14 @@ public class BlinkLightningConnectionStringHandler : ILightningConnectionStringH
         // Non-custodial (Spark) accounts: identified by an "ln-address" (or bare "username") key
         // and the absence of an "api-key". These have no GraphQL wallet-id and can only receive,
         // via LNURL-pay + LUD-21 verify brokered by blink-lnurl-server.
-        if (!kv.ContainsKey("api-key") &&
-            (kv.TryGetValue("ln-address", out var lnAddress) || kv.TryGetValue("username", out lnAddress)))
+        if (IsLnAddressConnectionString(kv, out var lnAddress))
         {
             return CreateLnAddressClient(lnAddress, kv, network, out error);
         }
 
         if (!kv.TryGetValue("server", out var server))
         {
-            server = network.Name switch
-            {
-                nameof(Network.TestNet) => "https://api.staging.galoy.io/graphql",
-                nameof(Network.RegTest) => "http://localhost:4455/graphql",
-                _ => "https://api.blink.sv/graphql"
-            };
+            server = DefaultServer(network);
             // error = $"The key 'server' is mandatory for blink connection strings";
             // return null;
         }

--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkLnAddressLightningClient.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkLnAddressLightningClient.cs
@@ -83,30 +83,35 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
         HttpClient httpClient, ILogger logger)
     {
         _lightningAddress = lightningAddress;
-        var parts = lightningAddress.Split('@');
-        if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
-            throw new FormatException($"Invalid Blink lightning address '{lightningAddress}'");
-        _username = parts[0];
-        _domain = parts[1];
+        (_username, _domain) = ParseLightningAddress(lightningAddress);
         _usd = usd;
         _network = network;
         _httpClient = httpClient;
         _logger = logger;
     }
 
-    private Uri LnurlpMetadataUri
+    /// <summary>Splits a "user@domain" lightning address into its parts, throwing on an invalid address.</summary>
+    internal static (string Username, string Domain) ParseLightningAddress(string lightningAddress)
     {
-        get
-        {
-            // USDB uses a "+usd" wallet modifier on the local part (blink-lnurl-server identifier parsing).
-            var localPart = _usd ? $"{_username}+usd" : _username;
-            var scheme = _domain.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
-                         _domain.StartsWith("localhost:", StringComparison.OrdinalIgnoreCase)
-                ? "http"
-                : "https";
-            return new Uri($"{scheme}://{_domain}/.well-known/lnurlp/{Uri.EscapeDataString(localPart)}");
-        }
+        var parts = (lightningAddress ?? "").Split('@');
+        if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
+            throw new FormatException($"Invalid Blink lightning address '{lightningAddress}'");
+        return (parts[0], parts[1]);
     }
+
+    /// <summary>Builds the LNURL-pay metadata URL for a Blink lightning address. USDB uses a "+usd"
+    /// wallet modifier on the local part; localhost domains use http, everything else https.</summary>
+    internal static Uri BuildLnurlpMetadataUri(string username, string domain, bool usd)
+    {
+        var localPart = usd ? $"{username}+usd" : username;
+        var scheme = domain.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
+                     domain.StartsWith("localhost:", StringComparison.OrdinalIgnoreCase)
+            ? "http"
+            : "https";
+        return new Uri($"{scheme}://{domain}/.well-known/lnurlp/{Uri.EscapeDataString(localPart)}");
+    }
+
+    private Uri LnurlpMetadataUri => BuildLnurlpMetadataUri(_username, _domain, _usd);
 
     private async Task<JObject> FetchLnurlMetadata(CancellationToken cancellation)
     {
@@ -123,8 +128,8 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
             throw new Exception($"'{_lightningAddress}' is not a valid LNURL-pay endpoint.");
 
         // Cache the callback origin; the LUD-21 verify endpoint lives on the same host.
-        if (json["callback"]?.Value<string>() is { } cb && Uri.TryCreate(cb, UriKind.Absolute, out var cbUri))
-            _verifyOrigin = cbUri.GetLeftPart(UriPartial.Authority);
+        if (ExtractOrigin(json["callback"]?.Value<string>()) is { } origin)
+            _verifyOrigin = origin;
 
         return json;
     }
@@ -166,12 +171,7 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
         var amountMsat = createInvoiceRequest.Amount.MilliSatoshi;
         var min = metadata["minSendable"]?.Value<long>() ?? 1;
         var max = metadata["maxSendable"]?.Value<long>() ?? long.MaxValue;
-        if (amountMsat < min)
-            throw new Exception(
-                $"Amount {amountMsat} msat is below the minimum accepted by this Blink address ({min} msat).");
-        if (amountMsat > max)
-            throw new Exception(
-                $"Amount {amountMsat} msat is above the maximum accepted by this Blink address ({max} msat).");
+        ValidateAmountBounds(amountMsat, min, max);
 
         var callbackUri = new UriBuilder(callback);
         var query = new StringBuilder(callbackUri.Query.TrimStart('?'));
@@ -215,8 +215,8 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
 
         var paymentHash = bolt11.PaymentHash?.ToString() ?? throw new Exception("Invoice has no payment hash.");
         var verifyUrl = json["verify"]?.Value<string>();
-        if (!string.IsNullOrEmpty(verifyUrl) && Uri.TryCreate(verifyUrl, UriKind.Absolute, out var vu))
-            _verifyOrigin = vu.GetLeftPart(UriPartial.Authority);
+        if (ExtractOrigin(verifyUrl) is { } vOrigin)
+            _verifyOrigin = vOrigin;
         verifyUrl ??= BuildVerifyUrl(paymentHash);
         var expiresAt = bolt11.ExpiryDate;
 
@@ -240,7 +240,71 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
     {
         if (_verifyOrigin is null)
             throw new InvalidOperationException("Verify origin not resolved yet.");
-        return $"{_verifyOrigin}/verify/{paymentHash}";
+        return BuildVerifyUrl(_verifyOrigin, paymentHash);
+    }
+
+    /// <summary>Builds the LUD-21 verify URL from the verify origin (the LNURL-pay callback host)
+    /// and the payment hash.</summary>
+    internal static string BuildVerifyUrl(string verifyOrigin, string paymentHash)
+        => $"{verifyOrigin}/verify/{paymentHash}";
+
+    /// <summary>Extracts the origin (scheme://host[:port]) from an absolute http/https URL, or null if
+    /// it is not a valid absolute http/https URL. Used to derive the verify-endpoint host from the
+    /// LNURL callback URL. Non-http(s) schemes (e.g. the file:// that some platforms infer from a bare
+    /// relative path) are rejected.</summary>
+    internal static string? ExtractOrigin(string? url)
+        => !string.IsNullOrEmpty(url)
+           && Uri.TryCreate(url, UriKind.Absolute, out var u)
+           && (u.Scheme == Uri.UriSchemeHttp || u.Scheme == Uri.UriSchemeHttps)
+            ? u.GetLeftPart(UriPartial.Authority)
+            : null;
+
+    /// <summary>Throws if the requested amount (msat) is outside the LNURL min/max sendable bounds.</summary>
+    internal static void ValidateAmountBounds(long amountMsat, long minMsat, long maxMsat)
+    {
+        if (amountMsat < minMsat)
+            throw new Exception(
+                $"Amount {amountMsat} msat is below the minimum accepted by this Blink address ({minMsat} msat).");
+        if (amountMsat > maxMsat)
+            throw new Exception(
+                $"Amount {amountMsat} msat is above the maximum accepted by this Blink address ({maxMsat} msat).");
+    }
+
+    /// <summary>Determines the invoice status from settlement and expiry, relative to <paramref name="now"/>.</summary>
+    internal static LightningInvoiceStatus DetermineStatus(bool settled, DateTimeOffset expiresAt, DateTimeOffset now)
+    {
+        if (settled) return LightningInvoiceStatus.Paid;
+        if (expiresAt < now) return LightningInvoiceStatus.Expired;
+        return LightningInvoiceStatus.Unpaid;
+    }
+
+    /// <summary>Validates a Blink LUD-21 preimage against the payment hash: it must be 64 hex chars
+    /// and SHA256(preimage) must equal the (natural-order hex) payment hash. Returns the preimage when
+    /// valid, otherwise null.</summary>
+    internal static string? ValidatePreimage(string paymentHash, string? preimage)
+    {
+        var normalizedHash = paymentHash?.Trim().ToLowerInvariant();
+        if (preimage is not { Length: 64 } || !IsHex(preimage) || normalizedHash is not { Length: 64 })
+            return null;
+        try
+        {
+            var preimageBytes = Encoders.Hex.DecodeData(preimage);
+            var computedHex = Encoders.Hex.EncodeData(Hashes.SHA256(preimageBytes));
+            return computedHex.Equals(normalizedHash, StringComparison.OrdinalIgnoreCase) ? preimage : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Computes the next per-invoice back-off after a verify failure:
+    /// delay = min(pollInterval * 2^errors, maxBackoff). Returns the incremented error count and delay.</summary>
+    internal static (int Errors, TimeSpan Delay) NextBackoff(int previousErrors, TimeSpan pollInterval, TimeSpan maxBackoff)
+    {
+        var errors = previousErrors + 1;
+        var delayMs = Math.Min(pollInterval.TotalMilliseconds * Math.Pow(2, errors), maxBackoff.TotalMilliseconds);
+        return (errors, TimeSpan.FromMilliseconds(delayMs));
     }
 
     public async Task<LightningInvoice?> GetInvoice(string invoiceId, CancellationToken cancellation = new())
@@ -309,10 +373,7 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
     private LightningInvoice BuildInvoice(string paymentHash, TrackedInvoice tracked, bool settled, string? preimage)
     {
         var bolt11 = BOLT11PaymentRequest.Parse(tracked.Bolt11, _network);
-        LightningInvoiceStatus status;
-        if (settled) status = LightningInvoiceStatus.Paid;
-        else if (tracked.ExpiresAt < DateTimeOffset.UtcNow) status = LightningInvoiceStatus.Expired;
-        else status = LightningInvoiceStatus.Unpaid;
+        var status = DetermineStatus(settled, tracked.ExpiresAt, DateTimeOffset.UtcNow);
 
         // The authoritative payment hash is the verify key (the `paymentHash` argument = BTCPay's
         // invoice Id), NOT the hash parsed from the returned `pr`. blink-lnurl-server's verify
@@ -334,23 +395,9 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
 
         // BTCPay validates the preimage: it must be 64 hex chars and SHA256(preimage)==paymentHash.
         // If invalid, drop it (the payment is still recorded, just without a preimage).
-        string? validPreimage = null;
-        if (settled && preimage is { Length: 64 } && IsHex(preimage) && normalizedPaymentHash.Length == 64)
-        {
-            try
-            {
-                var preimageBytes = Encoders.Hex.DecodeData(preimage);
-                var computedHex = Encoders.Hex.EncodeData(Hashes.SHA256(preimageBytes));
-                if (computedHex.Equals(normalizedPaymentHash, StringComparison.OrdinalIgnoreCase))
-                    validPreimage = preimage;
-                else
-                    _logger.LogWarning("Blink preimage for {PaymentHash} does not hash to the payment hash (got {Computed}); discarding.", paymentHash, computedHex);
-            }
-            catch (Exception e)
-            {
-                _logger.LogDebug(e, "Failed to validate Blink preimage for {PaymentHash}", paymentHash);
-            }
-        }
+        var validPreimage = settled ? ValidatePreimage(paymentHash, preimage) : null;
+        if (settled && preimage is not null && validPreimage is null)
+            _logger.LogWarning("Blink preimage for {PaymentHash} did not validate against the payment hash; discarding.", paymentHash);
 
         return new LightningInvoice
         {
@@ -367,7 +414,7 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
         };
     }
 
-    private static bool IsHex(string s)
+    internal static bool IsHex(string s)
     {
         foreach (var c in s)
             if (!Uri.IsHexDigit(c))
@@ -471,12 +518,11 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
                         {
                             // Capped exponential back-off so a degraded blink-lnurl-server is not
                             // hammered every 3s per invoice.
-                            var errors = (_backoff.TryGetValue(paymentHash, out var prev) ? prev.Errors : 0) + 1;
-                            var delayMs = Math.Min(PollInterval.TotalMilliseconds * Math.Pow(2, errors),
-                                MaxBackoff.TotalMilliseconds);
-                            _backoff[paymentHash] = (errors, DateTimeOffset.UtcNow.AddMilliseconds(delayMs));
+                            var prevErrors = _backoff.TryGetValue(paymentHash, out var prev) ? prev.Errors : 0;
+                            var (errors, delay) = NextBackoff(prevErrors, PollInterval, MaxBackoff);
+                            _backoff[paymentHash] = (errors, DateTimeOffset.UtcNow.Add(delay));
                             _logger.LogDebug(e, "Error polling Blink invoice {PaymentHash} (attempt {Errors}); backing off {DelayMs}ms",
-                                paymentHash, errors, delayMs);
+                                paymentHash, errors, delay.TotalMilliseconds);
                         }
                     }
 


### PR DESCRIPTION
## Summary

Adds a unit-test suite for the Blink plugin, focused on the **payment/invoice status mappings** ("payment status hooks") plus the other pure logic in both the custodial and non-custodial clients.

Follows the existing lightweight pattern (`BTCPayServer.Plugins.Electrum.Tests`): a new `BTCPayServer.Plugins.Blink.Tests` project (xunit.v3, net10.0) that references only the plugin + BTCPayServer runtime, so it builds and runs in ~1s. **77 tests, all passing.**

## Refactor to enable testing

The status/enum mappings were inlined inside async GraphQL/HTTP methods. To make them testable without network I/O, they were extracted into `internal static` helpers and exposed via `InternalsVisibleTo`. These are behavior-preserving moves, with two small robustness improvements noted below.

**Custodial (`BlinkLightningClient`):** `MapInvoiceStatus`, `MapPaymentStatus`, `MapPayResult`, `MapPayDetailStatus`, `MapNetwork`.

**Non-custodial (`BlinkLnAddressLightningClient`):** `ValidatePreimage`, `DetermineStatus`, `NextBackoff`, `ParseLightningAddress`, `BuildLnurlpMetadataUri`, `BuildVerifyUrl`, `ExtractOrigin`, `ValidateAmountBounds`, `IsHex`.

**Handler:** `DefaultServer`, `IsLnAddressConnectionString`.

## Behavior improvements surfaced by the tests

- `MapInvoiceStatus` previously mapped only `EXPIRED/PAID/PENDING` with no default arm, so an unexpected Blink `paymentStatus` (or null) would throw a `SwitchExpressionException` and abort payment processing. It now degrades unknown/null to `Unpaid`. The `Pay` result and pay-detail mappings similarly no longer throw on unknown values.
- `ExtractOrigin` now only accepts `http`/`https` origins (a test caught that `Uri.TryCreate(UriKind.Absolute)` infers `file://` from a bare relative path on some platforms).

## Coverage

- **Status hooks:** invoice/payment/pay/pay-detail/network/currency mappings, including unknown-input regression cases.
- **Non-custodial:** LUD-21 preimage validation (positive via a verified fixture + a generated pair, and negatives), settled/expired/unpaid status decision (clock-injected), back-off growth + 30s cap, lightning-address parsing, `+usd`/localhost metadata-URL building, verify-URL/origin construction, amount bounds.
- **Connection-string routing:** ln-address vs api-key, `username=` alias, default server per network.

The custodial runtime path is otherwise unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when Blink returns unknown or unexpected payment, invoice, network, or currency values.
  * Improved handling of Blink Lightning addresses, including validation, URL construction, payment status detection, and amount limits.
  * Clarified routing between custodial and Lightning-address connection types.

* **Tests**
  * Added comprehensive automated coverage for Blink connection routing, status mapping, Lightning-address handling, preimages, URLs, polling, and amount validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->