### PR TITLE
FileSeller: fix ArgumentException + metadata overload binding (rebased on master)

### DIFF
--- a/Plugins/BTCPayServer.Plugins.FileSeller/BTCPayServer.Plugins.FileSeller.csproj
+++ b/Plugins/BTCPayServer.Plugins.FileSeller/BTCPayServer.Plugins.FileSeller.csproj
@@ -9,7 +9,7 @@
     <PropertyGroup>
         <Product>File Seller</Product>
         <Description>Allows you to sell files through the point of sale/crowdfund apps.</Description>
-        <Version>1.0.8</Version>
+        <Version>1.0.9</Version>
 <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
     <!-- Plugin development properties -->

--- a/Plugins/BTCPayServer.Plugins.FileSeller/FileSellerService.cs
+++ b/Plugins/BTCPayServer.Plugins.FileSeller/FileSellerService.cs
@@ -113,33 +113,64 @@ namespace BTCPayServer.Plugins.FileSeller
                     }
                 }
 
-                var loadedFiles = await _storedFileRepository.GetFiles(new StoredFileRepository.FilesQuery()
+                // Guard: when no cart item maps to a file-backed product, fileIds is empty.
+                // StoredFileRepository.GetFiles treats an empty Id filter as "no filter" and
+                // would return every file in the instance, which then crashes the FileName-keyed
+                // ToDictionary below whenever any two stored files share the same file name.
+                // Skip file processing entirely in that case.
+                if (fileIds.Count > 0)
                 {
-                    Id = fileIds.ToArray()
-                });
-                var productLinkTasks = loadedFiles.ToDictionary(file => file,
-                    file => _fileService.GetFileUrl(UrlToUse, file.Id));
-
-                var res = await Task.WhenAll(productLinkTasks.Values);
-
-
-                if (res.Any(s => !string.IsNullOrEmpty(s)))
-                {
-                    var productTitleToFile = productLinkTasks.Select(pair => (pair.Key.FileName, pair.Value.Result))
-                        .Where(s => s.Result is not null)
-                        .ToDictionary(tuple => tuple.FileName, tuple => tuple.Result);
-
-                    var receiptData = new JObject();
-                    receiptData.Add("Downloadable Content", JObject.FromObject(productTitleToFile));
-
-                    if (invoiceEvent.Invoice.Metadata.AdditionalData?.TryGetValue("receiptData",
-                            out var existingReceiptData) is true &&
-                        existingReceiptData is JObject existingReceiptDataObj)
+                    var loadedFiles = await _storedFileRepository.GetFiles(new StoredFileRepository.FilesQuery()
                     {
-                        receiptData.Merge(existingReceiptDataObj);
-                    }
+                        Id = fileIds.ToArray()
+                    });
+                    var productLinkTasks = loadedFiles.ToDictionary(file => file,
+                        file => _fileService.GetFileUrl(UrlToUse, file.Id));
 
-                    await _invoiceRepository.UpdateInvoiceMetadata(invoiceEvent.InvoiceId, "receiptData", receiptData);
+                    var res = await Task.WhenAll(productLinkTasks.Values);
+
+
+                    if (res.Any(s => !string.IsNullOrEmpty(s)))
+                    {
+                        // Two stored files can legitimately share the same FileName, so we cannot
+                        // key the receipt data on FileName alone. Disambiguate colliding names by
+                        // inserting a counter before the extension (e.g. "file.jpg", "file (2).jpg")
+                        // so every download link is preserved instead of throwing on a duplicate key.
+                        var productTitleToFile = new Dictionary<string, string>();
+                        foreach (var (fileName, url) in productLinkTasks
+                                     .Select(pair => (pair.Key.FileName, pair.Value.Result))
+                                     .Where(s => s.Result is not null))
+                        {
+                            var key = fileName;
+                            var suffix = 2;
+                            while (productTitleToFile.ContainsKey(key))
+                            {
+                                var nameWithoutExt = System.IO.Path.GetFileNameWithoutExtension(fileName);
+                                var ext = System.IO.Path.GetExtension(fileName);
+                                key = $"{nameWithoutExt} ({suffix}){ext}";
+                                suffix++;
+                            }
+
+                            productTitleToFile.Add(key, url);
+                        }
+
+                        var receiptData = new JObject();
+                        receiptData.Add("Downloadable Content", JObject.FromObject(productTitleToFile));
+
+                        if (invoiceEvent.Invoice.Metadata.AdditionalData?.TryGetValue("receiptData",
+                                out var existingReceiptData) is true &&
+                            existingReceiptData is JObject existingReceiptDataObj)
+                        {
+                            receiptData.Merge(existingReceiptDataObj);
+                        }
+
+                        // Cast to object so this binds to the new atomic
+                        // UpdateInvoiceMetadata(invoiceId, key, object) overload. Without the cast,
+                        // a JObject value resolves to the obsolete (invoiceId, storeId, JObject)
+                        // overload, which overwrites the whole metadata blob (the very race this
+                        // change is meant to avoid).
+                        await _invoiceRepository.UpdateInvoiceMetadata(invoiceEvent.InvoiceId, "receiptData", (object)receiptData);
+                    }
                 }
 
                 await _invoiceRepository.UpdateInvoiceMetadata(invoiceEvent.InvoiceId, "fileselleractivated", "true");


### PR DESCRIPTION
Rebased on `master` (post-#142) per @Kukks's request, and reviewed the findings across all plugins.

This keeps the atomic `UpdateInvoiceMetadata` API introduced in #142 and adds three fixes to **File Seller**:

### 1. Guard the empty file set (original `ArgumentException`)
When an invoice qualifies but no cart item maps to a file-backed product, `fileIds` is empty. `StoredFileRepository.GetFiles(new FilesQuery { Id = fileIds.ToArray() })` treats an empty `Id[]` as *no filter* and returns **every file in the instance**. Skipping the lookup when `fileIds` is empty avoids that.

### 2. Disambiguate duplicate receipt file names
`.ToDictionary(tuple => tuple.FileName, …)` throws `ArgumentException: An item with the same key has already been added` whenever two stored files share a name (common). Colliding names now get a counter before the extension (`file.jpg`, `file (2).jpg`) so every download link is preserved.

### 3. Fix the metadata overload binding (regression introduced in #142)
`receiptData` is a `JObject`, so:

```csharp
await _invoiceRepository.UpdateInvoiceMetadata(invoiceEvent.InvoiceId, "receiptData", receiptData);
```

resolved to the **`[Obsolete]`** `UpdateInvoiceMetadata(string invoiceId, string storeId, JObject metadata)` overload rather than the new `(string invoiceId, string metadataKey, object metadataValue)` one — because `JObject` is more specific than `object`. That takes the whole-blob path (treating `"receiptData"` as `storeId`) and **overwrites the entire metadata blob**, i.e. the exact race #142/#7475 is meant to remove. Casting the value to `object` forces the atomic overload.

### Cross-plugin audit ("fix your findings across all plugins")

I checked every 3-arg `UpdateInvoiceMetadata` call site on `master`; only File Seller's `receiptData` call mis-bound. The rest already bind to the atomic `object` overload:

| Plugin / call | Value | Type | Binding |
|---|---|---|---|
| BitcoinSwitch `bitcoinswitchactivated` | `"true"` | `string` | ✅ atomic |
| DataErasure `buyer*` (×9) | `"erased"` | `string` | ✅ atomic |
| **FileSeller `receiptData`** | `receiptData` | **`JObject`** | ❌ obsolete → **fixed here** |
| FileSeller `fileselleractivated` | `"true"` | `string` | ✅ atomic |
| NIP05 `Nostr` | `new Dictionary<string,string>()` | `Dictionary` | ✅ atomic |
| TicketTailor `holdId` | `(object)null!` | `object` | ✅ atomic |
| TicketTailor `holdId_deleted` | `holdIdx` | `string` | ✅ atomic |
| TicketTailor `ticketIds` | `issuedTicketIds` | `JArray` | ✅ atomic (`JArray` isn't a `JObject`) |

So only File Seller needed a code change; the others are unaffected.

### Build

All five migrated plugins (FileSeller, BitcoinSwitch, NIP05, TicketTailor, DataErasure) build `Release` for `net10.0` against the `master` submodule pin (`2ed0fa1`) with **0 errors and no `UpdateInvoiceMetadata`-related `CS0618`** warnings. File Seller builds completely clean.

Version bumped `1.0.8 → 1.0.9`.

Closes #139. Related: #142, btcpayserver/btcpayserver#7475, btcpayserver/btcpayserver#7468.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented file processing when no files are selected.
  * Fixed download handling for duplicate file names so all download links remain available.
  * Improved resilience of receipt metadata updates to avoid incorrect metadata overwrites in these scenarios.
* **Chores**
  * Updated the File Seller plugin package version to 1.0.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->