### PR TITLE
Remove Microsoft.CodeAnalysis package references

### DIFF
--- a/Plugins/BTCPayServer.Plugins.MicroNode/BTCPayServer.Plugins.MicroNode.csproj
+++ b/Plugins/BTCPayServer.Plugins.MicroNode/BTCPayServer.Plugins.MicroNode.csproj
@@ -37,7 +37,5 @@
         <PackageReference Include="AsyncKeyedLock" Version="7.0.1" />
         <PackageReference Include="FlexLabs.EntityFrameworkCore.Upsert" Version="10.0.0" />
         <PackageReference Include="Laraue.EfCoreTriggers.PostgreSql" Version="10.4.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.3.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
This package is transitively referenced by BTCPayServer.Ratings.

Keeping it here means there is build issues when BTCPayServer.Ratings bump those package (and we do in 2.4.1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused development dependencies from the MicroNode plugin.
  * No user-facing functionality or behavior was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->