### PR TITLE
Fix: Race condition on metadata update

### DIFF
--- a/Plugins/BTCPayServer.Plugins.BitcoinSwitch/BTCPayServer.Plugins.BitcoinSwitch.csproj
+++ b/Plugins/BTCPayServer.Plugins.BitcoinSwitch/BTCPayServer.Plugins.BitcoinSwitch.csproj
@@ -9,7 +9,7 @@
     <PropertyGroup>
         <Product>Bitcoin Switch</Product>
         <Description>Control harwdare using the POS as a switch</Description>
-        <Version>1.0.2</Version>
+        <Version>1.0.3</Version>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
     <!-- Plugin development properties -->

--- a/Plugins/BTCPayServer.Plugins.BitcoinSwitch/BitcoinSwitchPlugin.cs
+++ b/Plugins/BTCPayServer.Plugins.BitcoinSwitch/BitcoinSwitchPlugin.cs
@@ -12,7 +12,7 @@ public class BitcoinSwitchPlugin : BaseBTCPayServerPlugin
 {
     public override IBTCPayServerPlugin.PluginDependency[] Dependencies { get; } =
     {
-        new() {Identifier = nameof(BTCPayServer), Condition = ">=2.3.7"}
+        new() {Identifier = nameof(BTCPayServer), Condition = ">=2.4.1"}
     };
 
     public override void Execute(IServiceCollection applicationBuilder)

--- a/Plugins/BTCPayServer.Plugins.BitcoinSwitch/BitcoinSwitchService.cs
+++ b/Plugins/BTCPayServer.Plugins.BitcoinSwitch/BitcoinSwitchService.cs
@@ -141,10 +141,7 @@ List<AppCartItem> cartItems = null;
                 //         });
                 // }
                 
-                invoiceEvent.Invoice.Metadata.SetAdditionalData("bitcoinswitchactivated", "true");
-                
-                await _invoiceRepository.UpdateInvoiceMetadata(invoiceEvent.InvoiceId, invoiceEvent.Invoice.StoreId,
-                    invoiceEvent.Invoice.Metadata.ToJObject());
+                await _invoiceRepository.UpdateInvoiceMetadata(invoiceEvent.InvoiceId, "bitcoinswitchactivated", "true");
                 
                 
             }

--- a/Plugins/BTCPayServer.Plugins.DataErasure/BTCPayServer.Plugins.DataErasure.csproj
+++ b/Plugins/BTCPayServer.Plugins.DataErasure/BTCPayServer.Plugins.DataErasure.csproj
@@ -9,7 +9,7 @@
     <PropertyGroup>
         <Product>Data Erasure</Product>
         <Description>Allows you to erase user data from invoices after a period of time.</Description>
-        <Version>1.0.3</Version>
+        <Version>1.0.4</Version>
 <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
     <!-- Plugin development properties -->

--- a/Plugins/BTCPayServer.Plugins.DataErasure/DataErasurePlugin.cs
+++ b/Plugins/BTCPayServer.Plugins.DataErasure/DataErasurePlugin.cs
@@ -9,7 +9,7 @@ namespace BTCPayServer.Plugins.DataErasure
     {
         public override IBTCPayServerPlugin.PluginDependency[] Dependencies { get; } =
         {
-            new() { Identifier = nameof(BTCPayServer), Condition = ">=2.3.7" }
+            new() { Identifier = nameof(BTCPayServer), Condition = ">=2.4.1" }
         };
         public override void Execute(IServiceCollection applicationBuilder)
         {

--- a/Plugins/BTCPayServer.Plugins.DataErasure/DataErasureService.cs
+++ b/Plugins/BTCPayServer.Plugins.DataErasure/DataErasureService.cs
@@ -95,25 +95,23 @@ namespace BTCPayServer.Plugins.DataErasure
                             {
                                 //replace all buyer info with "erased"
                                 if (!string.IsNullOrEmpty(invoice.Metadata.BuyerAddress1))
-                                    invoice.Metadata.BuyerAddress1 = "erased";
+                                    await _invoiceRepository.UpdateInvoiceMetadata(invoice.Id, "buyerAddress1", "erased");
                                 if (!string.IsNullOrEmpty(invoice.Metadata.BuyerAddress2))
-                                    invoice.Metadata.BuyerAddress2 = "erased";
+                                    await _invoiceRepository.UpdateInvoiceMetadata(invoice.Id, "buyerAddress2", "erased");
                                 if (!string.IsNullOrEmpty(invoice.Metadata.BuyerCity))
-                                    invoice.Metadata.BuyerCity = "erased";
+                                    await _invoiceRepository.UpdateInvoiceMetadata(invoice.Id, "buyerCity", "erased");
                                 if (!string.IsNullOrEmpty(invoice.Metadata.BuyerCountry))
-                                    invoice.Metadata.BuyerCountry = "erased";
+                                    await _invoiceRepository.UpdateInvoiceMetadata(invoice.Id, "buyerCountry", "erased");
                                 if (!string.IsNullOrEmpty(invoice.Metadata.BuyerEmail))
-                                    invoice.Metadata.BuyerEmail = "erased";
+                                    await _invoiceRepository.UpdateInvoiceMetadata(invoice.Id, "buyerEmail", "erased");
                                 if (!string.IsNullOrEmpty(invoice.Metadata.BuyerName))
-                                    invoice.Metadata.BuyerName = "erased";
+                                    await _invoiceRepository.UpdateInvoiceMetadata(invoice.Id, "buyerName", "erased");
                                 if (!string.IsNullOrEmpty(invoice.Metadata.BuyerPhone))
-                                    invoice.Metadata.BuyerPhone = "erased";
+                                    await _invoiceRepository.UpdateInvoiceMetadata(invoice.Id, "buyerPhone", "erased");
                                 if (!string.IsNullOrEmpty(invoice.Metadata.BuyerState))
-                                    invoice.Metadata.BuyerState = "erased";
+                                    await _invoiceRepository.UpdateInvoiceMetadata(invoice.Id, "buyerState", "erased");
                                 if (!string.IsNullOrEmpty(invoice.Metadata.BuyerZip))
-                                    invoice.Metadata.BuyerZip = "erased";
-                                await _invoiceRepository.UpdateInvoiceMetadata(invoice.Id, invoice.StoreId,
-                                    invoice.Metadata.ToJObject());
+                                    await _invoiceRepository.UpdateInvoiceMetadata(invoice.Id, "buyerZip", "erased");
                                 count++;
                             }
 

--- a/Plugins/BTCPayServer.Plugins.FileSeller/BTCPayServer.Plugins.FileSeller.csproj
+++ b/Plugins/BTCPayServer.Plugins.FileSeller/BTCPayServer.Plugins.FileSeller.csproj
@@ -9,7 +9,7 @@
     <PropertyGroup>
         <Product>File Seller</Product>
         <Description>Allows you to sell files through the point of sale/crowdfund apps.</Description>
-        <Version>1.0.7</Version>
+        <Version>1.0.8</Version>
 <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
     <!-- Plugin development properties -->

--- a/Plugins/BTCPayServer.Plugins.FileSeller/FileSellerPlugin.cs
+++ b/Plugins/BTCPayServer.Plugins.FileSeller/FileSellerPlugin.cs
@@ -9,7 +9,7 @@ public class FileSellerPlugin : BaseBTCPayServerPlugin
 {
     public override IBTCPayServerPlugin.PluginDependency[] Dependencies { get; } =
     {
-        new() {Identifier = nameof(BTCPayServer), Condition = ">=2.3.7"}
+        new() {Identifier = nameof(BTCPayServer), Condition = ">=2.4.1"}
     };
 
     public override void Execute(IServiceCollection applicationBuilder)

--- a/Plugins/BTCPayServer.Plugins.FileSeller/FileSellerService.cs
+++ b/Plugins/BTCPayServer.Plugins.FileSeller/FileSellerService.cs
@@ -139,12 +139,10 @@ namespace BTCPayServer.Plugins.FileSeller
                         receiptData.Merge(existingReceiptDataObj);
                     }
 
-                    invoiceEvent.Invoice.Metadata.SetAdditionalData("receiptData", receiptData);
+                    await _invoiceRepository.UpdateInvoiceMetadata(invoiceEvent.InvoiceId, "receiptData", receiptData);
                 }
 
-                invoiceEvent.Invoice.Metadata.SetAdditionalData("fileselleractivated", "true");
-                await _invoiceRepository.UpdateInvoiceMetadata(invoiceEvent.InvoiceId, invoiceEvent.Invoice.StoreId,
-                    invoiceEvent.Invoice.Metadata.ToJObject());
+                await _invoiceRepository.UpdateInvoiceMetadata(invoiceEvent.InvoiceId, "fileselleractivated", "true");
             }
 
             await base.ProcessEvent(evt, cancellationToken);

--- a/Plugins/BTCPayServer.Plugins.NIP05/BTCPayServer.Plugins.NIP05.csproj
+++ b/Plugins/BTCPayServer.Plugins.NIP05/BTCPayServer.Plugins.NIP05.csproj
@@ -11,7 +11,7 @@
     <PropertyGroup>
         <Product>Nostr</Product>
         <Description>NIP5 addresses, Zap support, Nostr Wallet Connect Lightning support</Description>
-        <Version>1.1.19</Version>
+        <Version>1.1.20</Version>
 <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
     <!-- Plugin development properties -->

--- a/Plugins/BTCPayServer.Plugins.NIP05/Nip05Plugin.cs
+++ b/Plugins/BTCPayServer.Plugins.NIP05/Nip05Plugin.cs
@@ -13,7 +13,7 @@ namespace BTCPayServer.Plugins.NIP05
     {
         public override IBTCPayServerPlugin.PluginDependency[] Dependencies { get; } =
         {
-            new() {Identifier = nameof(BTCPayServer), Condition = ">=2.3.7"}
+            new() {Identifier = nameof(BTCPayServer), Condition = ">=2.4.1"}
         };
 
         public override void Execute(IServiceCollection applicationBuilder)

--- a/Plugins/BTCPayServer.Plugins.NIP05/Zapper.cs
+++ b/Plugins/BTCPayServer.Plugins.NIP05/Zapper.cs
@@ -200,13 +200,12 @@ public class Zapper : IHostedService
 
         zapReceipt = await zapReceipt.ComputeIdAndSignAsync(key);
         relays = relays.Concat(userNostrSettings?.Relays ?? Array.Empty<string>()).Distinct().ToArray();
-        arg.Invoice.Metadata.SetAdditionalData("Nostr", new Dictionary<string,string>()
+        await _invoiceRepository.UpdateInvoiceMetadata(arg.InvoiceId, "Nostr", new Dictionary<string,string>()
         {
             {"Zap Request", zapRequestEvent.Id},
             {"Zap Receipt", zapReceipt.Id},
             {"Relays", string.Join(',', relays)}
         });
-        await _invoiceRepository.UpdateInvoiceMetadata(arg.InvoiceId, arg.Invoice.StoreId, arg.Invoice.Metadata.ToJObject());
         _pendingZapEvents.Add(new PendingZapEvent(relays, zapReceipt));
     }
 

--- a/Plugins/BTCPayServer.Plugins.TicketTailor/BTCPayServer.Plugins.TicketTailor.csproj
+++ b/Plugins/BTCPayServer.Plugins.TicketTailor/BTCPayServer.Plugins.TicketTailor.csproj
@@ -9,7 +9,7 @@
     <PropertyGroup>
         <Product>TicketTailor</Product>
         <Description>Allows you to integrate with TicketTailor.com to sell tickets for Bitcoin</Description>
-        <Version>2.0.8</Version>
+        <Version>2.0.9</Version>
 <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
     <!-- Plugin development properties -->

--- a/Plugins/BTCPayServer.Plugins.TicketTailor/TicketTailorPlugin.cs
+++ b/Plugins/BTCPayServer.Plugins.TicketTailor/TicketTailorPlugin.cs
@@ -14,7 +14,7 @@ namespace BTCPayServer.Plugins.TicketTailor
     {
         public override IBTCPayServerPlugin.PluginDependency[] Dependencies { get; } =
         {
-            new() {Identifier = nameof(BTCPayServer), Condition = ">=2.3.7"}
+            new() {Identifier = nameof(BTCPayServer), Condition = ">=2.4.1"}
         };
 
         public override void Execute(IServiceCollection applicationBuilder)

--- a/Plugins/BTCPayServer.Plugins.TicketTailor/TicketTailorWebhookProvider.cs
+++ b/Plugins/BTCPayServer.Plugins.TicketTailor/TicketTailorWebhookProvider.cs
@@ -101,10 +101,8 @@ public class TicketTailorWebhookProvider(
                         "Deleting the hold as the invoice is invalid/expired.", invoice, invLogs, false);
                     if (await new TicketTailorClient(httpClientFactory, settings.ApiKey).DeleteHold(holdIdx))
                     {
-                        invoice.Metadata.AdditionalData.Remove("holdId");
-                        invoice.Metadata.AdditionalData.Add("holdId_deleted", holdIdx);
-                        await invoiceRepository.UpdateInvoiceMetadata(invoice.Id, invoice.StoreId,
-                            invoice.Metadata.ToJObject());
+                        await invoiceRepository.UpdateInvoiceMetadata(invoice.Id, "holdId", (object)null!);
+                        await invoiceRepository.UpdateInvoiceMetadata(invoice.Id, "holdId_deleted", holdIdx);
                     }
                 }
 
@@ -185,8 +183,7 @@ public class TicketTailorWebhookProvider(
                 }
 
 
-                invoice.Metadata.AdditionalData["ticketIds"] =
-                    new JArray(tickets.Select(issuedTicket => issuedTicket.Id));
+                var issuedTicketIds = new JArray(tickets.Select(issuedTicket => issuedTicket.Id));
                 if (tickets.Count != holdOriginalAmount)
                 {
                     await HandleIssueTicketError($"Not all the held tickets were issued because: {String.Join(",", errors)}",
@@ -195,8 +192,7 @@ public class TicketTailorWebhookProvider(
                     return null;
                 }
 
-                await invoiceRepository.UpdateInvoiceMetadata(invoice.Id, invoice.StoreId,
-                    invoice.Metadata.ToJObject());
+                await invoiceRepository.UpdateInvoiceMetadata(invoice.Id, "ticketIds", issuedTicketIds);
                 await invoiceRepository.AddInvoiceLogs(invoice.Id, invLogs);
                 
                 if (settings.SendEmail)


### PR DESCRIPTION
Fix https://github.com/btcpayserver/btcpayserver/issues/7468 by using the new API provided by https://github.com/btcpayserver/btcpayserver/pull/7475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Updated plugins to support the latest BTCPay Server release.
  - Refreshed plugin package versions across Bitcoin Switch, Data Erasure, File Seller, NIP-05, and Ticket Tailor.

- **Bug Fixes**
  - Improved invoice metadata updates by changing targeted fields individually, helping prevent unrelated metadata from being overwritten.
  - Enhanced reliability for payment activation, buyer-data removal, file delivery, NIP-05 receipts, and ticket issuance metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->