### PR TITLE
Blink: probe fee before paying to settle at exact fee

### DIFF
--- a/BTCPayServer.Plugins.Blink.Tests/BlinkFeeProbeTests.cs
+++ b/BTCPayServer.Plugins.Blink.Tests/BlinkFeeProbeTests.cs
@@ -1,0 +1,45 @@
+using BTCPayServer.Lightning;
+using BTCPayServer.Plugins.Blink;
+using NBitcoin;
+using Xunit;
+
+// Tests for the fee-probe branch decision in the custodial client's Pay path.
+// Amount-carrying invoices must be probed (so Blink caches the route and settles at the
+// exact fee instead of its max fee reserve); zero-amount invoices carry no amount to probe
+// with here and must be paid as-is (ShouldProbeFee == false).
+public class BlinkFeeProbeTests
+{
+    // Amount-carrying mainnet invoices (from BlinkLightningClient.cs fixtures):
+    // 1u = 100 sat, 10n = 1 sat.
+    private const string AmountInvoice100Sat =
+        "lnbc1u1p5hn2dmpp5mcc880zq4jal99yztxmu2csjc83r7qcv6yfmfzd2fqzm5348w2ascqzyssp5z3lfcr54z3ssd93q2jyux2lah3v2ay7xs5fnd32j0pa3tfqrehgq9q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgqdq2w3jhxapjxgmqz9gxqyjw5qrzjqwryaup9lh50kkranzgcdnn2fgvx390wgj5jd07rwr3vxeje0glcll7fwunuepcqyyqqqqlgqqqqqeqqjqmwuxa4w3ushqy5687v79zf8zrh3fyhwc7d863j0lu8lj7xf48wl8mtvxz56rr6r8sy3u69e7xndhdrrw6k9vuzd98yw56u07d268d4gq5zj8u0";
+
+    private const string AmountInvoice1Sat =
+        "lnbc10n1pjn9nmzpp5a7znt4tv9gy5v6342xrgnntltkljffp255dph40vaf6964j27pvqhp59ly2g7flsy97vqahh9yue8qz7u6tvlpjfh9r0m9nzfezhm6fgmqscqzzsxqzursp55l9zht4zya3jyjdr9khr22z6afvjqdcw06l7vyd6tksdtsc8ezqs9qyyssqwswp9dnz9txv8t8zjrrts9rv4agu40ufqc04434f6lszdwvlhjk45m3pdcpqzghswkrcvgeaztcr6h82xp35suu64hnk4ms929pcahgpfg7sza";
+
+    // Zero-amount mainnet invoice (BOLT11 spec test vector: "Please consider supporting this
+    // project" donation invoice — no amount encoded in the human-readable part 'lnbc1...').
+    private const string ZeroAmountInvoice =
+        "lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w";
+
+    [Fact]
+    public void ShouldProbeFee_true_for_amount_invoice_100sat()
+    {
+        var bolt11 = BOLT11PaymentRequest.Parse(AmountInvoice100Sat, Network.Main);
+        Assert.True(BlinkLightningClient.ShouldProbeFee(bolt11));
+    }
+
+    [Fact]
+    public void ShouldProbeFee_true_for_amount_invoice_1sat()
+    {
+        var bolt11 = BOLT11PaymentRequest.Parse(AmountInvoice1Sat, Network.Main);
+        Assert.True(BlinkLightningClient.ShouldProbeFee(bolt11));
+    }
+
+    [Fact]
+    public void ShouldProbeFee_false_for_zero_amount_invoice()
+    {
+        var bolt11 = BOLT11PaymentRequest.Parse(ZeroAmountInvoice, Network.Main);
+        Assert.False(BlinkLightningClient.ShouldProbeFee(bolt11));
+    }
+}

--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningClient.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningClient.cs
@@ -724,17 +724,99 @@ query GetWallet($walletId: WalletId!) {
         throw new NotSupportedException();
     }
 
-    public async Task<PayResponse> Pay(PayInvoiceParams payParams,
+    public Task<PayResponse> Pay(PayInvoiceParams payParams,
         CancellationToken cancellation = new CancellationToken())
     {
-        return await Pay(null, new PayInvoiceParams(), cancellation);
+        // This overload carries no bolt11 to pay. Blink's payment mutation requires a
+        // payment request, so there is nothing we can send here. Fail explicitly instead
+        // of forwarding a null bolt11 (which would throw an opaque NullReferenceException
+        // when parsing the invoice).
+        throw new NotSupportedException(
+            "Paying without a BOLT11 payment request is not supported by the Blink client.");
     }
 
     private static TimeSpan PayTimeout = TimeSpan.FromMinutes(1.0);
+
+    /// <summary>
+    /// Whether a fee probe should be attempted for the given invoice. Only amount-carrying
+    /// invoices can be probed here: a probe caches the route on the Blink backend so the
+    /// payment settles at the exact fee instead of Blink's max fee reserve. Zero-amount
+    /// invoices carry no amount to probe with (Pay receives no explicit amount), so they are
+    /// paid as-is.
+    /// </summary>
+    internal static bool ShouldProbeFee(BOLT11PaymentRequest bolt11)
+        => bolt11.MinimumAmount > LightMoney.Zero;
+
+    /// <summary>
+    /// Probes the route for the fee of an amount-carrying lightning invoice.
+    /// Probing caches the route on the Blink backend so the subsequent payment
+    /// settles with the exact fee instead of Blink's max fee reserve.
+    /// This is best-effort: any failure is logged and swallowed so the payment
+    /// still proceeds (Blink will then fall back to its max fee reserve).
+    /// </summary>
+    private async Task ProbeFee(string bolt11, CancellationToken cancellation)
+    {
+        var request = new GraphQLRequest
+        {
+            Query = @"
+mutation LnInvoiceFeeProbe($input: LnInvoiceFeeProbeInput!) {
+  lnInvoiceFeeProbe(input: $input) {
+    amount
+    errors {
+      message
+    }
+  }
+}",
+            OperationName = "LnInvoiceFeeProbe",
+            Variables = new
+            {
+                input = new
+                {
+                    walletId = await GetWalletId(),
+                    paymentRequest = bolt11,
+                }
+            }
+        };
+
+        try
+        {
+            var response = (JObject)(await _client.SendQueryAsync<dynamic>(request, cancellation))
+                .Data.lnInvoiceFeeProbe;
+            if (response.TryGetValue("errors", out var error)
+                && error is JArray { Count: > 0 } arr)
+            {
+                Logger?.LogWarning(
+                    "Blink fee probe failed ('{Error}'), paying without probe.",
+                    arr[0]["message"]?.Value<string>());
+            }
+            else
+            {
+                // The probe caches the route on the Blink backend so the payment
+                // settles at this exact fee instead of Blink's max fee reserve. This
+                // is the real route fee: some destinations (e.g. swap/Spark providers)
+                // legitimately cost more to reach, which is correct, not an overcharge.
+                Logger?.LogDebug(
+                    "Blink fee probe succeeded: route fee {Amount} sat.",
+                    response["amount"]?.Value<long?>());
+            }
+        }
+        catch (Exception exc)
+        {
+            Logger?.LogWarning(exc, "Blink fee probe errored, paying without probe.");
+        }
+    }
+
     public async Task<PayResponse> Pay(string bolt11, PayInvoiceParams payParams,
         CancellationToken cancellation = default)
     {
-        
+        var bolt11Parsed = BOLT11PaymentRequest.Parse(bolt11, _network);
+
+        // Probe amount invoices first so Blink caches the route and settles at the
+        // exact fee instead of its max fee reserve. Zero-amount invoices carry no
+        // amount to probe with here, so they are paid as-is (best-effort, no reject).
+        if (ShouldProbeFee(bolt11Parsed))
+            await ProbeFee(bolt11, cancellation);
+
         var request = new GraphQLRequest
         {
             Query = @"
@@ -777,7 +859,6 @@ mutation LnInvoicePaymentSend($input: LnInvoicePaymentInput!) {
                 }
             }
         };
-        var bolt11Parsed = BOLT11PaymentRequest.Parse(bolt11, _network);
 
         using var inner = new CancellationTokenSource(payParams?.SendTimeout ?? PayTimeout);
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellation,inner.Token);


### PR DESCRIPTION
## Summary

The Blink custodial client paid invoices via `lnInvoicePaymentSend` **without probing the route first**, so Blink applied its maximum fee reserve (a ~10 sat floor) to every payment. Small payments were overcharged — e.g. a 10 sat fee on a payment whose real route fee is 1 sat.

This PR probes the route with `lnInvoiceFeeProbe` before paying. Probing caches the route on the Blink backend, so the subsequent `lnInvoicePaymentSend` settles at the **exact route fee** instead of the max reserve. The probed amount is the real cost of reaching the destination, so payments now pay only what the route actually costs.

## Details

- **`ProbeFee`** — runs `lnInvoiceFeeProbe` (`{ paymentRequest, walletId } → SatAmountPayload { amount, errors }`) before the payment send. Best-effort: any probe error is logged and swallowed so the payment still proceeds (Blink then falls back to its reserve).
- **`ShouldProbeFee`** — only amount-carrying invoices are probed. `lnInvoiceFeeProbe` takes no amount, and zero-amount invoices have no amount to probe with here (`Pay` receives no separate amount), so they are paid as-is.
- **Overload hardening** — `Pay(PayInvoiceParams, CancellationToken)` previously forwarded a `null` bolt11 and would throw an opaque `NullReferenceException`; it now throws a clear `NotSupportedException`.

## Tests

Adds `BlinkFeeProbeTests` covering the probe-branch selection (amount invoice → probe; zero-amount invoice → no probe), using real BOLT11 vectors. Full Blink test suite: **86 passing**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fee probing for Blink payments with invoices that specify an amount, helping determine applicable fees before payment submission.
  * Fee-probe errors or unavailable results no longer prevent the payment from proceeding.

* **Bug Fixes**
  * Blink payments now clearly require a BOLT11 payment request.
  * Improved handling for zero-amount invoices, which bypass fee probing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->