### PR TITLE
Blink: support top-up (amountless) invoices for all account types

### DIFF
--- a/BTCPayServer.Plugins.Blink.Tests/BlinkCustodialModeTests.cs
+++ b/BTCPayServer.Plugins.Blink.Tests/BlinkCustodialModeTests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using BTCPayServer.Lightning;
+using BTCPayServer.Plugins.Blink;
+using NBitcoin;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+// Tests for the custodial ln-address mode: GraphQL endpoint derivation and the description-hash
+// computation used to commit a directly-minted invoice to BTCPay's own LNURL metadata.
+public class BlinkCustodialModeTests
+{
+    // --- GraphQLEndpointForDomain ------------------------------------------------------------
+
+    [Fact]
+    public void Blink_sv_maps_to_api_blink_sv()
+    {
+        Assert.Equal(new Uri("https://api.blink.sv/graphql"),
+            BlinkGraphQLPublicClient.GraphQLEndpointForDomain("blink.sv"));
+    }
+
+    [Fact]
+    public void Blink_sv_is_case_insensitive()
+    {
+        Assert.Equal(new Uri("https://api.blink.sv/graphql"),
+            BlinkGraphQLPublicClient.GraphQLEndpointForDomain("Blink.SV"));
+    }
+
+    [Fact]
+    public void Self_hosted_domain_gets_api_subdomain()
+    {
+        Assert.Equal(new Uri("https://api.pay.example.com/graphql"),
+            BlinkGraphQLPublicClient.GraphQLEndpointForDomain("pay.example.com"));
+    }
+
+    [Fact]
+    public void Domain_already_prefixed_with_api_is_not_doubled()
+    {
+        Assert.Equal(new Uri("https://api.example.com/graphql"),
+            BlinkGraphQLPublicClient.GraphQLEndpointForDomain("api.example.com"));
+    }
+
+    [Fact]
+    public void Localhost_uses_http()
+    {
+        Assert.Equal(new Uri("http://api.localhost/graphql"),
+            BlinkGraphQLPublicClient.GraphQLEndpointForDomain("localhost"));
+    }
+
+    // --- ComputeDescriptionHashHex -----------------------------------------------------------
+
+    private static string Sha256Hex(string s)
+    {
+        using var sha = SHA256.Create();
+        return Convert.ToHexString(sha.ComputeHash(Encoding.UTF8.GetBytes(s))).ToLowerInvariant();
+    }
+
+    [Fact]
+    public void DescriptionHashOnly_hashes_the_description_metadata()
+    {
+        var metadata = "[[\"text/plain\",\"BTCPay store\"]]";
+        var req = new CreateInvoiceParams(LightMoney.Satoshis(21), metadata, TimeSpan.FromMinutes(15))
+        {
+            DescriptionHashOnly = true
+        };
+        var hex = BlinkLnAddressLightningClient.ComputeDescriptionHashHex(req);
+        Assert.Equal(Sha256Hex(metadata), hex);
+    }
+
+    [Fact]
+    public void Explicit_description_hash_is_preferred()
+    {
+        var dh = new uint256(Sha256Hex("anything"));
+        var req = new CreateInvoiceParams(LightMoney.Satoshis(21), "desc", TimeSpan.FromMinutes(15))
+        {
+            DescriptionHash = dh
+        };
+        var hex = BlinkLnAddressLightningClient.ComputeDescriptionHashHex(req);
+        Assert.Equal(dh.ToString(), hex);
+    }
+
+    [Fact]
+    public void No_hash_when_not_description_hash_only()
+    {
+        // A plain memo (no DescriptionHashOnly, no DescriptionHash) => memo is used, not a hash.
+        var req = new CreateInvoiceParams(LightMoney.Satoshis(21), "a human memo", TimeSpan.FromMinutes(15));
+        Assert.Null(BlinkLnAddressLightningClient.ComputeDescriptionHashHex(req));
+    }
+
+    // --- ParseAccountInfo: JSON-null data must NOT throw (regression guard) -------------------
+
+    [Fact]
+    public void ParseAccountInfo_custodial_resolves_wallet()
+    {
+        var resp = JObject.Parse(
+            "{\"data\":{\"accountDefaultWallet\":{\"id\":\"0515bb4d-9064-46ba-885a-306e3324c547\",\"walletCurrency\":\"BTC\"}}}");
+        var (info, confident) = BlinkGraphQLPublicClient.ParseAccountInfo(resp);
+        Assert.Equal(BlinkGraphQLPublicClient.AccountKind.Custodial, info.Kind);
+        Assert.Equal("0515bb4d-9064-46ba-885a-306e3324c547", info.WalletId);
+        Assert.Equal("BTC", info.WalletCurrency);
+        Assert.True(confident); // a resolved wallet is safe to cache
+    }
+
+    [Fact]
+    public void ParseAccountInfo_noncustodial_does_not_exist_is_confident()
+    {
+        // This is the exact shape Blink returns for a Spark username - previously threw
+        // "Cannot access child value on JValue" and broke metadata mirroring for Spark addresses.
+        var resp = JObject.Parse(
+            "{\"data\":null,\"errors\":[{\"message\":\"Account does not exist for username twentyone\"}]}");
+        var (info, confident) = BlinkGraphQLPublicClient.ParseAccountInfo(resp);
+        Assert.Equal(BlinkGraphQLPublicClient.AccountKind.NonCustodial, info.Kind);
+        Assert.Null(info.WalletId);
+        Assert.True(confident); // an explicit "does not exist" is a confident Spark verdict
+    }
+
+    [Fact]
+    public void ParseAccountInfo_ambiguous_error_is_not_confident()
+    {
+        // A transient/ambiguous data:null error (rate-limit, timeout surfaced as 200, server error)
+        // must NOT be cached as NonCustodial - otherwise one blip pins a valid custodial account to
+        // the LNURL fallback for the whole plugin lifetime.
+        foreach (var message in new[] { "internal server error", "rate limited", "Something went wrong" })
+        {
+            var resp = JObject.Parse(
+                "{\"data\":null,\"errors\":[{\"message\":\"" + message + "\"}]}");
+            var (info, confident) = BlinkGraphQLPublicClient.ParseAccountInfo(resp);
+            Assert.Equal(BlinkGraphQLPublicClient.AccountKind.NonCustodial, info.Kind); // safe fallback for this call
+            Assert.False(confident); // but not cached
+        }
+    }
+
+    // --- ParseStatus: null-safe -------------------------------------------------------------
+
+    [Fact]
+    public void ParseStatus_reads_status()
+    {
+        var resp = JObject.Parse(
+            "{\"data\":{\"lnInvoicePaymentStatusByHash\":{\"status\":\"PAID\"}}}");
+        Assert.Equal("PAID", BlinkGraphQLPublicClient.ParseStatus(resp));
+    }
+
+    [Fact]
+    public void ParseStatus_unknown_invoice_data_null_returns_null()
+    {
+        var resp = JObject.Parse("{\"data\":null,\"errors\":[{\"message\":\"not found\"}]}");
+        Assert.Null(BlinkGraphQLPublicClient.ParseStatus(resp));
+    }
+
+    // --- ParseInvoiceResult: success + error surfacing --------------------------------------
+
+    [Fact]
+    public void ParseInvoiceResult_success()
+    {
+        var resp = JObject.Parse(
+            "{\"data\":{\"lnInvoiceCreateOnBehalfOfRecipient\":{\"invoice\":{\"paymentHash\":\"ab\",\"paymentRequest\":\"lnbc1xyz\"},\"errors\":[]}}}");
+        var (pr, ph) = BlinkGraphQLPublicClient.ParseInvoiceResult(resp, "lnInvoiceCreateOnBehalfOfRecipient");
+        Assert.Equal("lnbc1xyz", pr);
+        Assert.Equal("ab", ph);
+    }
+
+    [Fact]
+    public void ParseInvoiceResult_field_error_surfaces_message()
+    {
+        var resp = JObject.Parse(
+            "{\"data\":{\"lnInvoiceCreateOnBehalfOfRecipient\":{\"invoice\":null,\"errors\":[{\"message\":\"amount too small\"}]}}}");
+        var ex = Assert.Throws<Exception>(() =>
+            BlinkGraphQLPublicClient.ParseInvoiceResult(resp, "lnInvoiceCreateOnBehalfOfRecipient"));
+        Assert.Equal("amount too small", ex.Message);
+    }
+
+    [Fact]
+    public void ParseInvoiceResult_toplevel_error_data_null_surfaces_message()
+    {
+        var resp = JObject.Parse(
+            "{\"data\":null,\"errors\":[{\"message\":\"Something went wrong\"}]}");
+        var ex = Assert.Throws<Exception>(() =>
+            BlinkGraphQLPublicClient.ParseInvoiceResult(resp, "lnInvoiceCreateOnBehalfOfRecipient"));
+        Assert.Equal("Something went wrong", ex.Message);
+    }
+}

--- a/BTCPayServer.Plugins.Blink.Tests/BlinkLnurlRequestFilterTests.cs
+++ b/BTCPayServer.Plugins.Blink.Tests/BlinkLnurlRequestFilterTests.cs
@@ -1,0 +1,179 @@
+using BTCPayServer.Lightning;
+using BTCPayServer.Plugins.Blink;
+using LNURL;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+// Tests for the LNURL-pay alignment logic that lets non-custodial (Blink ln-address) stores serve
+// metadata/bounds matching the Blink-minted invoice, so strict (LUD-06) wallets accept the payment.
+public class BlinkLnurlRequestFilterTests
+{
+    // --- TryGetBlinkLnAddress: connection-string detection -------------------------------------
+
+    [Fact]
+    public void Detects_blink_ln_address_connection_string()
+    {
+        var ok = BlinkLnurlRequestFilter.TryGetBlinkLnAddress(
+            "type=blink;ln-address=twentyone@blink.sv", out var lnAddress, out var usd);
+        Assert.True(ok);
+        Assert.Equal("twentyone@blink.sv", lnAddress);
+        Assert.False(usd);
+    }
+
+    [Fact]
+    public void Bare_username_defaults_to_blink_sv_domain()
+    {
+        var ok = BlinkLnurlRequestFilter.TryGetBlinkLnAddress(
+            "type=blink;ln-address=twentyone", out var lnAddress, out _);
+        Assert.True(ok);
+        Assert.Equal("twentyone@blink.sv", lnAddress);
+    }
+
+    [Fact]
+    public void Usd_currency_sets_usd_flag()
+    {
+        var ok = BlinkLnurlRequestFilter.TryGetBlinkLnAddress(
+            "type=blink;ln-address=twentyone@blink.sv;currency=USD", out _, out var usd);
+        Assert.True(ok);
+        Assert.True(usd);
+    }
+
+    [Fact]
+    public void Custodial_api_key_is_not_ln_address()
+    {
+        var ok = BlinkLnurlRequestFilter.TryGetBlinkLnAddress(
+            "type=blink;api-key=blink_abc;server=https://api.blink.sv/graphql", out var lnAddress, out _);
+        Assert.False(ok);
+        Assert.Null(lnAddress);
+    }
+
+    [Fact]
+    public void Non_blink_connection_string_is_ignored()
+    {
+        var ok = BlinkLnurlRequestFilter.TryGetBlinkLnAddress(
+            "type=lnd-rest;server=https://mynode.example.com", out _, out _);
+        Assert.False(ok);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not a connection string")]
+    public void Invalid_connection_strings_do_not_throw(string connectionString)
+    {
+        Assert.False(BlinkLnurlRequestFilter.TryGetBlinkLnAddress(connectionString, out _, out _));
+    }
+
+    // --- ApplyBlinkParameters: metadata mirroring + bounds intersection ------------------------
+
+    private static JObject BlinkMeta(string metadata = "[[\"text/plain\",\"Pay to twentyone@blink.sv\"]]",
+        long minSendable = 1000, long maxSendable = 50000000000, int commentAllowed = 255)
+        => new()
+        {
+            ["metadata"] = metadata,
+            ["minSendable"] = minSendable,
+            ["maxSendable"] = maxSendable,
+            ["commentAllowed"] = commentAllowed
+        };
+
+    [Fact]
+    public void Mirrors_blink_metadata_so_description_hash_matches()
+    {
+        var req = new LNURLPayRequest { Metadata = "[[\"text/plain\",\"BTCPay store\"]]" };
+        BlinkLnurlRequestFilter.ApplyBlinkParameters(req, BlinkMeta());
+        Assert.Equal("[[\"text/plain\",\"Pay to twentyone@blink.sv\"]]", req.Metadata);
+    }
+
+    [Fact]
+    public void Topup_bounds_are_narrowed_to_blink_limits()
+    {
+        // BTCPay top-up defaults: 1 sat .. 6.12 BTC. Blink: 1 sat .. 0.5 BTC.
+        var req = new LNURLPayRequest
+        {
+            MinSendable = LightMoney.Satoshis(1),
+            MaxSendable = LightMoney.FromUnit(6.12m, LightMoneyUnit.BTC)
+        };
+        BlinkLnurlRequestFilter.ApplyBlinkParameters(req, BlinkMeta());
+        Assert.Equal(LightMoney.MilliSatoshis(1000), req.MinSendable);
+        Assert.Equal(LightMoney.MilliSatoshis(50000000000), req.MaxSendable);
+    }
+
+    [Fact]
+    public void Fixed_amount_invoice_bounds_are_preserved_when_within_blink_range()
+    {
+        // A fixed-amount invoice has min == max; it must stay exact after alignment.
+        var fixedAmt = LightMoney.Satoshis(21000);
+        var req = new LNURLPayRequest { MinSendable = fixedAmt, MaxSendable = fixedAmt };
+        BlinkLnurlRequestFilter.ApplyBlinkParameters(req, BlinkMeta());
+        Assert.Equal(fixedAmt, req.MinSendable);
+        Assert.Equal(fixedAmt, req.MaxSendable);
+    }
+
+    [Fact]
+    public void Bounds_are_never_widened_beyond_btcpay_request()
+    {
+        // Blink advertises a wider range than BTCPay; we must not widen BTCPay's own bounds.
+        var req = new LNURLPayRequest
+        {
+            MinSendable = LightMoney.Satoshis(10),
+            MaxSendable = LightMoney.Satoshis(1000)
+        };
+        BlinkLnurlRequestFilter.ApplyBlinkParameters(req, BlinkMeta(minSendable: 1000, maxSendable: 50000000000));
+        Assert.Equal(LightMoney.Satoshis(10), req.MinSendable);   // not lowered to 1 sat
+        Assert.Equal(LightMoney.Satoshis(1000), req.MaxSendable); // not raised to 0.5 BTC
+    }
+
+    [Fact]
+    public void Disjoint_ranges_leave_btcpay_bounds_untouched()
+    {
+        // Degenerate: Blink's minimum (10 sat) exceeds BTCPay's maximum (5 sat) - the intersection is
+        // empty. We must NOT fabricate a fixed amount Blink would reject; leave BTCPay's bounds as-is
+        // (the callback's own amount-bounds check rejects out-of-range amounts cleanly).
+        var req = new LNURLPayRequest
+        {
+            MinSendable = LightMoney.Satoshis(1),
+            MaxSendable = LightMoney.Satoshis(5)
+        };
+        BlinkLnurlRequestFilter.ApplyBlinkParameters(req, BlinkMeta(minSendable: 10000 /*10 sat*/, maxSendable: 50000000000));
+        Assert.Equal(LightMoney.Satoshis(1), req.MinSendable);
+        Assert.Equal(LightMoney.Satoshis(5), req.MaxSendable);
+    }
+
+    [Fact]
+    public void Comment_allowed_is_capped_to_blink_limit()
+    {
+        var req = new LNURLPayRequest { CommentAllowed = 2000 };
+        BlinkLnurlRequestFilter.ApplyBlinkParameters(req, BlinkMeta(commentAllowed: 255));
+        Assert.Equal(255, req.CommentAllowed);
+    }
+
+    [Fact]
+    public void Comment_allowed_not_raised_when_btcpay_lower()
+    {
+        var req = new LNURLPayRequest { CommentAllowed = 100 };
+        BlinkLnurlRequestFilter.ApplyBlinkParameters(req, BlinkMeta(commentAllowed: 255));
+        Assert.Equal(100, req.CommentAllowed);
+    }
+
+    // --- custodial mode: metadata must NOT be mirrored ---------------------------------------
+
+    [Fact]
+    public void Custodial_mode_does_not_replace_metadata_but_still_narrows_bounds()
+    {
+        // For custodial accounts the invoice commits to BTCPay's own metadata, so mirroring must be
+        // skipped (mirrorMetadata=false) - otherwise the description hash mismatches AND a
+        // text/identifier leaks that makes the Blink app pay intraledger, bypassing the invoice.
+        var original = "[[\"text/plain\",\"BTCPay store\"]]";
+        var req = new LNURLPayRequest
+        {
+            Metadata = original,
+            MinSendable = LightMoney.Satoshis(1),
+            MaxSendable = LightMoney.FromUnit(6.12m, LightMoneyUnit.BTC)
+        };
+        BlinkLnurlRequestFilter.ApplyBlinkParameters(req, BlinkMeta(), mirrorMetadata: false);
+        // metadata untouched...
+        Assert.Equal(original, req.Metadata);
+        // ...but bounds still narrowed to Blink's limits.
+        Assert.Equal(LightMoney.MilliSatoshis(50000000000), req.MaxSendable);
+    }
+}

--- a/Plugins/BTCPayServer.Plugins.Blink/BTCPayServer.Plugins.Blink.csproj
+++ b/Plugins/BTCPayServer.Plugins.Blink/BTCPayServer.Plugins.Blink.csproj
@@ -9,7 +9,7 @@
     <PropertyGroup>
         <Product>Blink</Product>
         <Description>Blink Lightning support</Description>
-        <Version>1.1.0</Version>
+        <Version>1.1.1</Version>
 <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <RootNamespace>BTCPayServer.Plugins.Blink</RootNamespace>
     </PropertyGroup>

--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkGraphQLPublicClient.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkGraphQLPublicClient.cs
@@ -1,0 +1,210 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace BTCPayServer.Plugins.Blink;
+
+/// <summary>
+/// Thin wrapper around Blink's public GraphQL API for the operations that do NOT require an API key
+/// (see https://dev.blink.sv/api/no-api-key-operations):
+/// <list type="bullet">
+///   <item><c>accountDefaultWallet(username)</c> - resolves the default wallet of a username. Used to
+///   detect whether a Blink lightning address points at a custodial Galoy account (resolves) or a
+///   non-custodial Spark account (does not resolve).</item>
+///   <item><c>lnInvoiceCreateOnBehalfOfRecipient</c> / <c>lnNoAmountInvoiceCreateOnBehalfOfRecipient</c>
+///   - mints an invoice for a recipient wallet.</item>
+///   <item><c>lnInvoicePaymentStatusByHash</c> - polls an invoice's settlement status. This is
+///   ledger-aware, so it reports PAID even when Galoy smart-settles a Blink-to-Blink payment
+///   intraledger (which never touches the LNURL LUD-21 verify endpoint).</item>
+/// </list>
+///
+/// Detecting the account type this way lets the plugin mint custodial invoices directly (committing
+/// to BTCPay's own description metadata) instead of proxying the LNURL-pay server. That both restores
+/// the store description in the payer's wallet and - critically - avoids the Blink mobile app's
+/// "pay intraledger if the LNURL identifier is one of our own domains" shortcut, which otherwise
+/// bypasses BTCPay's invoice entirely and leaves the payment undetected.
+/// </summary>
+internal static class BlinkGraphQLPublicClient
+{
+    public enum AccountKind
+    {
+        /// <summary>Username resolves to a Galoy wallet: a custodial Blink account.</summary>
+        Custodial,
+        /// <summary>Username does not resolve: a non-custodial (Spark) account served only via LNURL.</summary>
+        NonCustodial
+    }
+
+    public record AccountInfo(AccountKind Kind, string? WalletId, string? WalletCurrency);
+
+    // Cache resolution per (endpoint,username) so we don't re-query on every invoice/poll. Account
+    // type is effectively immutable for a given username within a BTCPay run.
+    private static readonly ConcurrentDictionary<string, AccountInfo> _accountCache = new();
+
+    /// <summary>Derives the public GraphQL endpoint for a Blink lightning-address domain. blink.sv uses
+    /// api.blink.sv; a bare "api." prefix is added for other domains; localhost keeps http.</summary>
+    internal static Uri GraphQLEndpointForDomain(string domain)
+    {
+        // Strip any port for the host check, but preserve it when rebuilding.
+        var host = domain;
+        var isLocal = host.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
+                      host.StartsWith("localhost:", StringComparison.OrdinalIgnoreCase);
+        var scheme = isLocal ? "http" : "https";
+
+        if (host.Equals("blink.sv", StringComparison.OrdinalIgnoreCase))
+            return new Uri("https://api.blink.sv/graphql");
+
+        // For self-hosted Galoy instances the API is conventionally on the "api." subdomain of the
+        // lightning-address domain; if it already starts with api., keep it as-is.
+        var apiHost = host.StartsWith("api.", StringComparison.OrdinalIgnoreCase) ? host : $"api.{host}";
+        return new Uri($"{scheme}://{apiHost}/graphql");
+    }
+
+    private static async Task<JObject> PostAsync(HttpClient httpClient, Uri endpoint, string query,
+        object variables, CancellationToken cancellation)
+    {
+        var payload = new JObject
+        {
+            ["query"] = query,
+            ["variables"] = JToken.FromObject(variables)
+        };
+        using var content = new StringContent(payload.ToString(), Encoding.UTF8, "application/json");
+        using var resp = await httpClient.PostAsync(endpoint, content, cancellation);
+        var body = await resp.Content.ReadAsStringAsync(cancellation);
+        if (!resp.IsSuccessStatusCode)
+            throw new Exception($"Blink GraphQL request failed (HTTP {(int)resp.StatusCode}).");
+        return JObject.Parse(body);
+    }
+
+    /// <summary>Resolves whether a username is custodial (default wallet resolves) or non-custodial,
+    /// caching the result. A GraphQL error of "does not exist" means non-custodial; a transport error
+    /// is rethrown so the caller can decide (we do NOT cache failures).</summary>
+    public static async Task<AccountInfo> ResolveAccountAsync(HttpClient httpClient, Uri endpoint,
+        string username, bool usd, CancellationToken cancellation)
+    {
+        var cacheKey = $"{endpoint}|{username}|{(usd ? "USD" : "BTC")}";
+        if (_accountCache.TryGetValue(cacheKey, out var cached))
+            return cached;
+
+        const string query = @"query AccountDefaultWallet($username: Username!, $walletCurrency: WalletCurrency) {
+  accountDefaultWallet(username: $username, walletCurrency: $walletCurrency) { id walletCurrency }
+}";
+        var resp = await PostAsync(httpClient, endpoint, query,
+            new { username, walletCurrency = usd ? "USD" : "BTC" }, cancellation);
+
+        var (info, confident) = ParseAccountInfo(resp);
+        // Only cache a confident verdict: a resolved wallet (custodial) or an explicit "account does
+        // not exist" (non-custodial). An ambiguous data:null with some other error (rate-limit,
+        // timeout surfaced as 200, transient server error) must NOT be cached as NonCustodial - doing
+        // so would pin a valid custodial account to the LNURL fallback for the whole plugin lifetime.
+        // In that case we return NonCustodial for THIS call (safe fallback) but re-resolve next time.
+        if (confident)
+            _accountCache[cacheKey] = info;
+        return info;
+    }
+
+    /// <summary>Parses an <c>accountDefaultWallet</c> response into an <see cref="AccountInfo"/> plus a
+    /// <c>Confident</c> flag indicating whether the verdict is safe to cache.
+    /// <list type="bullet">
+    ///   <item>A resolved wallet id =&gt; Custodial, confident.</item>
+    ///   <item>An explicit "does not exist" error =&gt; NonCustodial, confident (Spark username).</item>
+    ///   <item>Any other <c>data:null</c>/error (transient/ambiguous) =&gt; NonCustodial, NOT confident,
+    ///   so the caller can fall back for this call without caching a possibly-wrong verdict.</item>
+    /// </list>
+    /// Note the safe <c>as JObject</c> casts: for a non-custodial username <c>resp["data"]</c> is a
+    /// JSON-null <see cref="JValue"/>, not C# null, so <c>?.["..."]</c> would throw "Cannot access child
+    /// value on JValue" - the cast yields null instead.</summary>
+    internal static (AccountInfo Info, bool Confident) ParseAccountInfo(JObject resp)
+    {
+        var wallet = (resp["data"] as JObject)?["accountDefaultWallet"] as JObject;
+        if (wallet?["id"]?.Value<string>() is { Length: > 0 } walletId)
+            return (new AccountInfo(AccountKind.Custodial, walletId, wallet["walletCurrency"]?.Value<string>()), true);
+
+        var nonCustodial = new AccountInfo(AccountKind.NonCustodial, null, null);
+        return (nonCustodial, IsAccountDoesNotExist(resp));
+    }
+
+    /// <summary>True when the response's errors clearly indicate the username has no Blink account
+    /// (a Spark/non-custodial address), as opposed to a transient/ambiguous failure.</summary>
+    private static bool IsAccountDoesNotExist(JObject resp)
+    {
+        if (resp["errors"] is not JArray errors)
+            return false;
+        foreach (var err in errors)
+        {
+            var message = (err as JObject)?["message"]?.Value<string>();
+            if (message is not null &&
+                message.Contains("does not exist", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>Creates a fixed-amount invoice on behalf of a recipient wallet, committing to the given
+    /// description hash (32-byte hex) so the BOLT11 h-tag matches BTCPay's served LNURL metadata.</summary>
+    public static async Task<(string PaymentRequest, string PaymentHash)> CreateInvoiceOnBehalfAsync(
+        HttpClient httpClient, Uri endpoint, string recipientWalletId, long amountSat,
+        string? descriptionHashHex, string? memo, int expiresInMinutes, bool usd,
+        CancellationToken cancellation)
+    {
+        var mutationName = usd
+            ? "lnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipient"
+            : "lnInvoiceCreateOnBehalfOfRecipient";
+        var inputType = usd
+            ? "LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientInput"
+            : "LnInvoiceCreateOnBehalfOfRecipientInput";
+
+        var query = $@"mutation CreateInvoice($input: {inputType}!) {{
+  {mutationName}(input: $input) {{
+    invoice {{ paymentHash paymentRequest }}
+    errors {{ message }}
+  }}
+}}";
+
+        object input = descriptionHashHex is { Length: > 0 }
+            ? new { recipientWalletId, amount = amountSat, descriptionHash = descriptionHashHex, expiresIn = expiresInMinutes }
+            : new { recipientWalletId, amount = amountSat, memo, expiresIn = expiresInMinutes };
+        var resp = await PostAsync(httpClient, endpoint, query,
+            new { input }, cancellation);
+        return ParseInvoiceResult(resp, mutationName);
+    }
+
+    /// <summary>Polls the settlement status of an invoice by payment hash. Returns one of
+    /// "PENDING", "PAID", "EXPIRED", or null when the invoice is unknown / on error.</summary>
+    public static async Task<string?> GetPaymentStatusByHashAsync(HttpClient httpClient, Uri endpoint,
+        string paymentHash, CancellationToken cancellation)
+    {
+        const string query = @"query PaymentStatus($input: LnInvoicePaymentStatusByHashInput!) {
+  lnInvoicePaymentStatusByHash(input: $input) { status }
+}";
+        var resp = await PostAsync(httpClient, endpoint, query,
+            new { input = new { paymentHash } }, cancellation);
+        return ParseStatus(resp);
+    }
+
+    /// <summary>Parses an <c>lnInvoicePaymentStatusByHash</c> response, returning the status string or
+    /// null when the invoice is unknown (<c>data</c> null / errors present). Uses <c>as JObject</c> to
+    /// avoid the JSON-null <see cref="JValue"/> indexing exception.</summary>
+    internal static string? ParseStatus(JObject resp)
+        => ((resp["data"] as JObject)?["lnInvoicePaymentStatusByHash"] as JObject)?["status"]?.Value<string>();
+
+    /// <summary>Parses an invoice-create mutation response. Returns the (paymentRequest, paymentHash)
+    /// on success; otherwise throws with the GraphQL error message. Handles both a null <c>data</c>
+    /// (top-level error) and per-field <c>errors</c>, using <c>as JObject</c> to stay null-safe.</summary>
+    internal static (string PaymentRequest, string PaymentHash) ParseInvoiceResult(JObject resp, string mutationName)
+    {
+        var payload = (resp["data"] as JObject)?[mutationName] as JObject;
+        var invoice = payload?["invoice"] as JObject;
+        if (invoice?["paymentRequest"]?.Value<string>() is { Length: > 0 } pr)
+            return (pr, invoice["paymentHash"]?.Value<string>() ?? "");
+
+        // Prefer the mutation's own errors[]; fall back to the top-level errors[] (present when data is null).
+        var errors = (payload?["errors"] as JArray) ?? (resp["errors"] as JArray);
+        var message = errors is { Count: > 0 } ? (errors[0] as JObject)?["message"]?.Value<string>() : null;
+        throw new Exception(message ?? "Blink did not return an invoice.");
+    }
+}

--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningClient.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkLightningClient.cs
@@ -253,7 +253,11 @@ query InvoiceByPaymentHash($paymentHash: PaymentHash!, $walletId: WalletId!) {
         {
             Id = invoice["paymentHash"].Value<string>(),
             Amount = invoice["satoshis"] is null? bolt11.MinimumAmount:  LightMoney.Satoshis(invoice["satoshis"].Value<long>()),
-                Preimage =  invoice["paymentSecret"].Value<string>(),
+            // NOTE: do NOT map `paymentSecret` to Preimage. paymentSecret is the BOLT11 payment secret
+            // (the `s` tag), not the payment preimage. BTCPay validates SHA256(preimage) == paymentHash,
+            // which a payment secret fails, producing "has a preimage but it doesn't match the payment
+            // hash" warnings on every payment. Blink does not return the preimage at creation time, so
+            // leave it null; the preimage is not required for BTCPay to record the payment.
             PaidAt = status == LightningInvoiceStatus.Paid ? DateTimeOffset.UtcNow : null,
             Status =  status,
             BOLT11 =  invoice["paymentRequest"].Value<string>(),
@@ -489,6 +493,15 @@ query Transactions($walletId: WalletId!) {
     public async Task<LightningInvoice> CreateInvoice(CreateInvoiceParams createInvoiceRequest,
         CancellationToken cancellation = new())
     {
+        // Top-up / amountless invoices: BTCPay passes a null or zero amount (see
+        // LightningLikePaymentHandler which sends LightMoney.Zero for InvoiceType.TopUp). The
+        // fixed-amount mutations below require a positive amount, so route these to Blink's
+        // dedicated no-amount mutation instead. A single mutation covers both BTC and USD wallets.
+        if (createInvoiceRequest.Amount is null || createInvoiceRequest.Amount.MilliSatoshi <= 0)
+        {
+            return await CreateNoAmountInvoice(createInvoiceRequest, cancellation);
+        }
+
         var isUSD = (await GetWalletInfo()).WalletCurrency == BlinkCurrency.USD;
         var query = isUSD ? @"
 mutation lnInvoiceCreate($input: LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientInput!) {
@@ -556,6 +569,62 @@ mutation lnInvoiceCreate($input: LnInvoiceCreateOnBehalfOfRecipientInput!) {
             }
         }
         return ToInvoice(inv);
+    }
+
+    /// <summary>
+    /// Creates a top-up / amountless (no-amount) invoice via Blink's
+    /// <c>lnNoAmountInvoiceCreateOnBehalfOfRecipient</c> mutation. Unlike the fixed-amount
+    /// mutations, the no-amount mutation takes no <c>amount</c> and no <c>descriptionHash</c>, and
+    /// the same mutation works for both BTC and USD recipient wallets. The returned invoice has no
+    /// <c>satoshis</c> field; <see cref="ToInvoice"/> already falls back to the BOLT11 amount
+    /// (which is 0 for an amountless invoice) in that case.
+    /// </summary>
+    private async Task<LightningInvoice> CreateNoAmountInvoice(CreateInvoiceParams createInvoiceRequest,
+        CancellationToken cancellation)
+    {
+        const string query = @"
+mutation lnNoAmountInvoiceCreate($input: LnNoAmountInvoiceCreateOnBehalfOfRecipientInput!) {
+  lnNoAmountInvoiceCreateOnBehalfOfRecipient(input: $input) {
+    invoice {
+      createdAt
+      paymentHash
+      paymentRequest
+      paymentSecret
+      paymentStatus
+    },
+    errors{
+      message
+    }
+  }
+}";
+
+        var request = new GraphQLRequest
+        {
+            Query = query,
+            OperationName = "lnNoAmountInvoiceCreate",
+            Variables = new
+            {
+                input = new
+                {
+                    recipientWalletId = await GetWalletId(),
+                    memo = createInvoiceRequest.Description,
+                    expiresIn = (int)createInvoiceRequest.Expiry.TotalMinutes
+                }
+            }
+        };
+
+        var response = await _client.SendQueryAsync<dynamic>(request, cancellation);
+        var inv = response.Data.lnNoAmountInvoiceCreateOnBehalfOfRecipient.invoice as JObject;
+        if (inv is not null)
+            return ToInvoice(inv);
+
+        var errors = response.Data.lnNoAmountInvoiceCreateOnBehalfOfRecipient.errors as JArray;
+        if (errors is not null && errors.Any())
+            throw new Exception(errors.First()["message"].ToString());
+
+        // No invoice and no error: fail explicitly rather than passing null to ToInvoice (which would
+        // throw an opaque NullReferenceException while dereferencing the invoice fields).
+        throw new Exception("Blink did not return an invoice.");
     }
 
     public async Task<ILightningInvoiceListener> Listen(CancellationToken cancellation = new CancellationToken())

--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkLnAddressLightningClient.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkLnAddressLightningClient.cs
@@ -42,7 +42,10 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
     private readonly HttpClient _httpClient;
     private readonly ILogger _logger;
 
-    private record TrackedInvoice(string Bolt11, string? VerifyUrl, DateTimeOffset ExpiresAt);
+    // Custodial invoices are minted via the public GraphQL API and settle through
+    // lnInvoicePaymentStatusByHash (ledger-aware); non-custodial invoices are proxied from the LNURL
+    // server and settle through the LUD-21 verify URL. VerifyUrl is null for custodial invoices.
+    private record TrackedInvoice(string Bolt11, string? VerifyUrl, DateTimeOffset ExpiresAt, bool Custodial = false);
 
     // BTCPay creates SEPARATE client instances for creating invoices and for its payment
     // listener/poller. In-memory per-instance state would therefore not be visible to the listener.
@@ -113,6 +116,30 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
 
     private Uri LnurlpMetadataUri => BuildLnurlpMetadataUri(_username, _domain, _usd);
 
+    private Uri GraphQLEndpoint => BlinkGraphQLPublicClient.GraphQLEndpointForDomain(_domain);
+
+    /// <summary>
+    /// Resolves whether this lightning address points at a custodial Galoy account (in which case we
+    /// mint invoices directly via the public GraphQL API) or a non-custodial Spark account (LNURL proxy).
+    /// The result is cached by <see cref="BlinkGraphQLPublicClient"/>. On any transport error we fall
+    /// back to non-custodial (LNURL) behaviour, which works for both account types.
+    /// </summary>
+    private async Task<BlinkGraphQLPublicClient.AccountInfo> ResolveAccount(CancellationToken cancellation)
+    {
+        try
+        {
+            return await BlinkGraphQLPublicClient.ResolveAccountAsync(
+                _httpClient, GraphQLEndpoint, _username, _usd, cancellation);
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e, "Could not resolve Blink account type for {Address}; assuming non-custodial (LNURL).",
+                _lightningAddress);
+            return new BlinkGraphQLPublicClient.AccountInfo(
+                BlinkGraphQLPublicClient.AccountKind.NonCustodial, null, null);
+        }
+    }
+
     private async Task<JObject> FetchLnurlMetadata(CancellationToken cancellation)
     {
         using var resp = await _httpClient.GetAsync(LnurlpMetadataUri, cancellation);
@@ -157,16 +184,39 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
     public async Task<LightningInvoice> CreateInvoice(CreateInvoiceParams createInvoiceRequest,
         CancellationToken cancellation = new())
     {
+        // BTCPay allows a null amount for top-up/amountless invoices, but LNURL-pay is inherently
+        // amount-driven, so we require a concrete amount and fail with a clear message otherwise.
+        // BTCPay sends LightMoney.Zero (not null) for InvoiceType.TopUp, so reject <= 0 too.
+        //
+        // This is expected for top-up invoices and NOT a failure: BTCPay catches this per payment
+        // method and falls back to serving the LNURL QR, where the payer's wallet supplies the amount
+        // and the callback creates the invoice for that amount. BTCPay records the fallback in the
+        // invoice event log (shown in red) - the top-up invoice can still be paid via LNURL. Note this
+        // applies to any Blink lightning-address connection, including one pointing at a custodial
+        // account, because such connections only receive via LNURL-pay and cannot mint a bolt11 here.
+        // (Checked first so the routine top-up rejection avoids an unnecessary LNURL metadata fetch.)
+        if (createInvoiceRequest.Amount is null || createInvoiceRequest.Amount.MilliSatoshi <= 0)
+            throw new NotSupportedException(
+                "Blink lightning-address connections cannot create an amountless (top-up) bolt11 invoice. " +
+                "This is expected: BTCPay falls back to the LNURL payment method for top-up invoices, " +
+                "where the payer chooses the amount in their wallet.");
+
+        // Custodial Galoy accounts: mint the invoice directly via the public GraphQL API instead of
+        // proxying the LNURL server. This commits the BOLT11 to BTCPay's own description hash (so the
+        // store description shows in the payer's wallet) and, crucially, avoids serving a
+        // "text/identifier" that would make the Blink mobile app pay intraledger and bypass BTCPay's
+        // invoice entirely. Settlement is detected via lnInvoicePaymentStatusByHash (ledger-aware).
+        var account = await ResolveAccount(cancellation);
+        if (account.Kind == BlinkGraphQLPublicClient.AccountKind.Custodial && account.WalletId is { } walletId)
+        {
+            return await CreateCustodialInvoice(createInvoiceRequest, walletId, cancellation);
+        }
+
+        // Non-custodial (Spark) path: only now do we need the LNURL-pay metadata/callback.
         var metadata = await FetchLnurlMetadata(cancellation);
         var callback = metadata["callback"]?.Value<string>();
         if (string.IsNullOrEmpty(callback))
             throw new Exception("LNURL-pay response is missing a callback URL.");
-
-        // BTCPay allows a null amount for top-up/amountless invoices, but LNURL-pay is inherently
-        // amount-driven, so we require a concrete amount and fail with a clear message otherwise.
-        if (createInvoiceRequest.Amount is null)
-            throw new NotSupportedException(
-                "Blink non-custodial (Spark) accounts require an invoice amount; amountless/top-up invoices are not supported.");
 
         var amountMsat = createInvoiceRequest.Amount.MilliSatoshi;
         var min = metadata["minSendable"]?.Value<long>() ?? 1;
@@ -177,9 +227,13 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
         var query = new StringBuilder(callbackUri.Query.TrimStart('?'));
         if (query.Length > 0) query.Append('&');
         query.Append("amount=").Append(amountMsat);
-        // Pass along a description/comment when the endpoint allows comments (LUD-12).
+        // Pass along a description/comment when the endpoint allows comments (LUD-12). But when
+        // DescriptionHashOnly is set (the LNURL-pay callback path), Description is BTCPay's serialized
+        // LNURL metadata JSON, not a human-readable comment - forwarding that blob as a LUD-12 comment
+        // is wrong (and may be rejected by the LNURL server), so skip it in that case.
         var commentAllowed = metadata["commentAllowed"]?.Value<int>() ?? 0;
-        if (commentAllowed > 0 && !string.IsNullOrEmpty(createInvoiceRequest.Description))
+        if (commentAllowed > 0 && !createInvoiceRequest.DescriptionHashOnly &&
+            !string.IsNullOrEmpty(createInvoiceRequest.Description))
         {
             var comment = createInvoiceRequest.Description!;
             if (comment.Length > commentAllowed) comment = comment.Substring(0, commentAllowed);
@@ -231,6 +285,67 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
             Status = LightningInvoiceStatus.Unpaid,
             ExpiresAt = expiresAt
         };
+    }
+
+    /// <summary>
+    /// Mints a fixed-amount invoice for a custodial Galoy account via the public GraphQL API,
+    /// committing to BTCPay's own description hash so the returned BOLT11's h-tag matches the metadata
+    /// BTCPay serves to the payer. The invoice is tracked as custodial and settles via
+    /// lnInvoicePaymentStatusByHash.
+    /// </summary>
+    private async Task<LightningInvoice> CreateCustodialInvoice(CreateInvoiceParams createInvoiceRequest,
+        string walletId, CancellationToken cancellation)
+    {
+        var amountSat = (long)createInvoiceRequest.Amount!.ToUnit(LightMoneyUnit.Satoshi);
+
+        // Determine the description hash to commit to. In the LNURL callback path BTCPay passes the
+        // serialized metadata as Description with DescriptionHashOnly=true; hash it ourselves. If an
+        // explicit DescriptionHash is provided, prefer it.
+        var descriptionHashHex = ComputeDescriptionHashHex(createInvoiceRequest);
+        var memo = descriptionHashHex is null ? createInvoiceRequest.Description : null;
+        var expiresIn = Math.Max(1, (int)createInvoiceRequest.Expiry.TotalMinutes);
+
+        var (pr, _) = await BlinkGraphQLPublicClient.CreateInvoiceOnBehalfAsync(
+            _httpClient, GraphQLEndpoint, walletId, amountSat, descriptionHashHex, memo, expiresIn, _usd,
+            cancellation);
+
+        var bolt11 = BOLT11PaymentRequest.Parse(pr, _network);
+
+        // Defensive checks mirroring the LNURL path: the minted invoice must match the requested amount
+        // and, when a description hash was requested, carry that exact hash.
+        if (bolt11.MinimumAmount != createInvoiceRequest.Amount)
+            throw new Exception(
+                $"Blink minted an invoice for {bolt11.MinimumAmount.MilliSatoshi} msat but " +
+                $"{createInvoiceRequest.Amount.MilliSatoshi} msat was requested.");
+        if (createInvoiceRequest.DescriptionHash is { } dh && dh != bolt11.DescriptionHash)
+            throw new Exception("Blink minted an invoice with a mismatched description hash.");
+
+        var paymentHash = bolt11.PaymentHash?.ToString() ?? throw new Exception("Invoice has no payment hash.");
+        var expiresAt = bolt11.ExpiryDate;
+        _tracked[paymentHash] = new TrackedInvoice(pr, VerifyUrl: null, expiresAt, Custodial: true);
+
+        return new LightningInvoice
+        {
+            Id = paymentHash,
+            PaymentHash = paymentHash,
+            BOLT11 = pr,
+            Amount = bolt11.MinimumAmount,
+            Status = LightningInvoiceStatus.Unpaid,
+            ExpiresAt = expiresAt
+        };
+    }
+
+    /// <summary>Returns the 32-byte hex description hash to commit to, or null when none applies.
+    /// Prefers an explicit <c>DescriptionHash</c>; otherwise, when <c>DescriptionHashOnly</c> is set,
+    /// hashes the (metadata) Description - matching how BTCPay's LNURL endpoint computes the hash the
+    /// payer's wallet will verify.</summary>
+    internal static string? ComputeDescriptionHashHex(CreateInvoiceParams createInvoiceRequest)
+    {
+        if (createInvoiceRequest.DescriptionHash is { } dh)
+            return dh.ToString();
+        if (createInvoiceRequest.DescriptionHashOnly && !string.IsNullOrEmpty(createInvoiceRequest.Description))
+            return Encoders.Hex.EncodeData(Hashes.SHA256(Encoding.UTF8.GetBytes(createInvoiceRequest.Description!)));
+        return null;
     }
 
     // LUD-21 verify URLs on blink-lnurl-server are {verifyOrigin}/verify/{paymentHash}, where
@@ -311,6 +426,14 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
     {
         _tracked.TryGetValue(invoiceId, out var tracked);
 
+        // Custodial invoices settle through the ledger-aware GraphQL status query, not LUD-21 verify.
+        // A tracked custodial entry is authoritative; on a fresh listener instance (no tracked entry)
+        // fall back to resolving the account type so we still pick the right settlement source.
+        var isCustodial = tracked?.Custodial ??
+            (await ResolveAccount(cancellation)).Kind == BlinkGraphQLPublicClient.AccountKind.Custodial;
+        if (isCustodial)
+            return await GetCustodialInvoice(invoiceId, tracked, cancellation);
+
         // Resolve the verify URL statelessly. On a fresh client instance (BTCPay's listener/poller)
         // there is no tracked invoice, so derive the verify origin from LNURL metadata.
         string verifyUrl;
@@ -368,6 +491,66 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
         var expiresAt = tracked?.ExpiresAt ?? BOLT11PaymentRequest.Parse(pr, _network).ExpiryDate;
         var t = new TrackedInvoice(pr, verifyUrl, expiresAt);
         return BuildInvoice(invoiceId, t, settled, preimage);
+    }
+
+    /// <summary>
+    /// Settlement for custodial invoices via the ledger-aware <c>lnInvoicePaymentStatusByHash</c> query.
+    /// This reports PAID even when Galoy smart-settles a Blink-to-Blink payment intraledger, which the
+    /// LUD-21 verify endpoint would miss. No preimage is available from this query, so payments are
+    /// recorded without one (BTCPay supports this).
+    /// </summary>
+    private async Task<LightningInvoice?> GetCustodialInvoice(string invoiceId, TrackedInvoice? tracked,
+        CancellationToken cancellation)
+    {
+        string? status;
+        try
+        {
+            status = await BlinkGraphQLPublicClient.GetPaymentStatusByHashAsync(
+                _httpClient, GraphQLEndpoint, invoiceId, cancellation);
+        }
+        catch (Exception e)
+        {
+            // Transient error: keep the invoice tracked (return Unpaid rather than null) so BTCPay's
+            // poller retries instead of dropping it. Matches the LUD-21 path's behaviour.
+            _logger.LogDebug(e, "Blink GraphQL status poll failed for {PaymentHash}", invoiceId);
+            return new LightningInvoice
+            {
+                Id = invoiceId,
+                PaymentHash = invoiceId,
+                Status = LightningInvoiceStatus.Unpaid
+            };
+        }
+
+        if (status is null)
+            return null; // unknown invoice
+
+        var mapped = BlinkLightningClient.MapInvoiceStatus(status);
+        var settled = mapped == LightningInvoiceStatus.Paid;
+
+        LightMoney? amount = null;
+        string? bolt11 = tracked?.Bolt11;
+        DateTimeOffset? expiresAt = tracked?.ExpiresAt;
+        if (bolt11 is not null)
+        {
+            var parsed = BOLT11PaymentRequest.Parse(bolt11, _network);
+            amount = parsed.MinimumAmount;
+            expiresAt ??= parsed.ExpiryDate;
+        }
+
+        // Respect expiry the same way DetermineStatus does for the LUD-21 path.
+        var finalStatus = DetermineStatus(settled, expiresAt ?? DateTimeOffset.MaxValue, DateTimeOffset.UtcNow);
+
+        return new LightningInvoice
+        {
+            Id = invoiceId,
+            PaymentHash = invoiceId,
+            BOLT11 = bolt11,
+            Amount = amount,
+            AmountReceived = settled ? amount : null,
+            Status = finalStatus,
+            PaidAt = settled ? DateTimeOffset.UtcNow : null,
+            ExpiresAt = expiresAt ?? default
+        };
     }
 
     private LightningInvoice BuildInvoice(string paymentHash, TrackedInvoice tracked, bool settled, string? preimage)

--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkLnurlRequestFilter.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkLnurlRequestFilter.cs
@@ -1,0 +1,209 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Services;
+using BTCPayServer.Data;
+using BTCPayServer.Lightning;
+using BTCPayServer.Payments;
+using BTCPayServer.Payments.Lightning;
+using BTCPayServer.Payments.LNURLPay;
+using BTCPayServer.Services.Invoices;
+using LNURL;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using Network = NBitcoin.Network;
+
+namespace BTCPayServer.Plugins.Blink;
+
+/// <summary>
+/// Aligns BTCPay's served LNURL-pay parameters with Blink's when a store's BTC lightning backend is
+/// a Blink non-custodial (Spark) lightning address.
+///
+/// Why this is required: for such a store the payable BOLT11 is minted by Blink's LNURL server (the
+/// <see cref="BlinkLnAddressLightningClient"/> proxies it), and that invoice commits, via its BOLT11
+/// <c>h</c> (description hash) tag, to <em>Blink's own</em> LNURL metadata. BTCPay by default serves
+/// its <em>own</em> metadata (store name/description). LUD-06 requires the payer's wallet to check
+/// that SHA256(served metadata) equals the invoice's <c>h</c> tag; the two differ, so strict wallets
+/// (e.g. Phoenix, Blitz) refuse to pay. By mirroring Blink's metadata here the hashes match and the
+/// payment succeeds. This also corrects the advertised min/max sendable to Blink's real limits.
+///
+/// Tradeoff: the payer's wallet then shows Blink's identity line ("Pay to user@blink.sv") rather than
+/// the store description. This is unavoidable because the description hash is committed by Blink.
+/// </summary>
+public class BlinkLnurlRequestFilter : PluginHookFilter<LNURLPayRequest>
+{
+    public override string Hook => "modify-lnurlp-request";
+
+    private readonly PaymentMethodHandlerDictionary _handlers;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<BlinkLnurlRequestFilter> _logger;
+
+    public BlinkLnurlRequestFilter(
+        PaymentMethodHandlerDictionary handlers,
+        IHttpClientFactory httpClientFactory,
+        ILogger<BlinkLnurlRequestFilter> logger)
+    {
+        _handlers = handlers;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public override async Task<LNURLPayRequest> Execute(LNURLPayRequest arg)
+    {
+        try
+        {
+            if (arg is not StoreLNURLPayRequest { Store: { } store })
+                return arg;
+
+            // Resolve the store's BTC lightning connection string and detect a Blink ln-address.
+            var lnPmi = PaymentTypes.LN.GetPaymentMethodId("BTC");
+            var configs = store.GetPaymentMethodConfigs<LightningPaymentMethodConfig>(_handlers, onlyEnabled: true);
+            if (!configs.TryGetValue(lnPmi, out var lnConfig))
+                return arg;
+            var connectionString = lnConfig.GetExternalLightningUrl();
+            if (!TryGetBlinkLnAddress(connectionString, out var lnAddress, out var usd))
+                return arg;
+
+            var (username, domain) = BlinkLnAddressLightningClient.ParseLightningAddress(lnAddress!);
+            var metadataUri = BlinkLnAddressLightningClient.BuildLnurlpMetadataUri(username, domain, usd);
+
+            using var httpClient = _httpClientFactory.CreateClient();
+            httpClient.Timeout = TimeSpan.FromSeconds(10);
+            using var resp = await httpClient.GetAsync(metadataUri, CancellationToken.None);
+            if (!resp.IsSuccessStatusCode)
+                return arg;
+            var json = JObject.Parse(await resp.Content.ReadAsStringAsync());
+
+            // Custodial accounts mint invoices directly via GraphQL committing to BTCPay's OWN metadata
+            // (see BlinkLnAddressLightningClient.CreateCustodialInvoice), so we must NOT replace the
+            // served metadata here - doing so would (a) break the description-hash match and (b) expose
+            // a "text/identifier" that makes the Blink mobile app pay intraledger and bypass the invoice.
+            // For non-custodial accounts the invoice is proxied from Blink's LNURL server and commits to
+            // Blink's metadata, so mirroring is required for strict wallets to accept it.
+            //
+            // Resolve in its OWN try/catch and default to mirroring on failure: a resolution error must
+            // degrade to the safe non-custodial behaviour (mirror), because the client's own resolver
+            // also falls back to the LNURL proxy path whose invoices require mirroring. Skipping
+            // mirroring on error would break strict-wallet payments for Spark addresses.
+            var mirrorMetadata = true;
+            try
+            {
+                var endpoint = BlinkGraphQLPublicClient.GraphQLEndpointForDomain(domain);
+                var account = await BlinkGraphQLPublicClient.ResolveAccountAsync(
+                    httpClient, endpoint, username, usd, CancellationToken.None);
+                mirrorMetadata = account.Kind == BlinkGraphQLPublicClient.AccountKind.NonCustodial;
+            }
+            catch (Exception e)
+            {
+                _logger.LogDebug(e,
+                    "Could not resolve Blink account type for {Address}; mirroring metadata (non-custodial default).",
+                    lnAddress);
+            }
+
+            ApplyBlinkParameters(arg, json, mirrorMetadata);
+            return arg;
+        }
+        catch (Exception e)
+        {
+            // Never break checkout because of this enhancement; the payment may still work for
+            // wallets that do not enforce the LUD-06 description-hash commitment.
+            _logger.LogWarning(e, "Failed to align LNURL-pay parameters with Blink; leaving BTCPay defaults.");
+            return arg;
+        }
+    }
+
+    /// <summary>Detects a Blink non-custodial (ln-address, no api-key) connection string and extracts
+    /// its lightning address and USD flag. Mirrors <see cref="BlinkLightningConnectionStringHandler"/>.</summary>
+    internal static bool TryGetBlinkLnAddress(string? connectionString, out string? lnAddress, out bool usd)
+    {
+        lnAddress = null;
+        usd = false;
+        if (string.IsNullOrEmpty(connectionString))
+            return false;
+
+        Dictionary<string, string> kv;
+        try
+        {
+            kv = LightningConnectionStringHelper.ExtractValues(connectionString, out var type);
+            if (type != "blink")
+                return false;
+        }
+        catch
+        {
+            return false;
+        }
+
+        if (!BlinkLightningConnectionStringHandler.IsLnAddressConnectionString(kv, out lnAddress) ||
+            string.IsNullOrWhiteSpace(lnAddress))
+            return false;
+
+        if (!lnAddress!.Contains('@'))
+            lnAddress = $"{lnAddress}@blink.sv";
+
+        if (kv.TryGetValue("currency", out var currencyStr))
+        {
+            try { usd = BlinkLightningClient.ParseBlinkCurrency(currencyStr) == BlinkCurrency.USD; }
+            catch (FormatException) { /* leave usd=false; invalid currency is handled elsewhere */ }
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Narrows the sendable bounds to the intersection of BTCPay's and Blink's limits (only ever
+    /// narrowed, never widened, so a fixed-amount invoice with min == max is preserved) and caps the
+    /// allowed comment length to Blink's. When <paramref name="mirrorMetadata"/> is true (non-custodial
+    /// accounts) it also overwrites the served metadata with Blink's, so the served-metadata hash
+    /// matches the invoice's committed description hash. For custodial accounts metadata is left intact.
+    /// </summary>
+    internal static void ApplyBlinkParameters(LNURLPayRequest arg, JObject blinkMetadata, bool mirrorMetadata = true)
+    {
+        if (mirrorMetadata)
+        {
+            var metadata = blinkMetadata["metadata"]?.Value<string>();
+            if (!string.IsNullOrEmpty(metadata))
+                arg.Metadata = metadata;
+        }
+
+        var blinkMin = blinkMetadata["minSendable"]?.Value<long>() is { } bmin ? new LightMoney(bmin) : null;
+        var blinkMax = blinkMetadata["maxSendable"]?.Value<long>() is { } bmax ? new LightMoney(bmax) : null;
+
+        // Compute the intersection of [BTCPay.Min, BTCPay.Max] and [Blink.Min, Blink.Max]. If the two
+        // ranges are DISJOINT (Blink's min exceeds BTCPay's max, or vice versa) there is no valid
+        // amount, so leave BTCPay's advertised bounds untouched rather than fabricating a fixed amount
+        // Blink would reject anyway. The callback's own ValidateAmountBounds still rejects any
+        // out-of-range amount cleanly, and disjoint ranges are not expected in practice (Blink's real
+        // minimum is 1 sat).
+        var newMin = Max(arg.MinSendable, blinkMin);
+        var newMax = Min(arg.MaxSendable, blinkMax);
+        if (newMin is null || newMax is null || newMin <= newMax)
+        {
+            if (newMin is not null)
+                arg.MinSendable = newMin;
+            if (newMax is not null)
+                arg.MaxSendable = newMax;
+        }
+
+        if (blinkMetadata["commentAllowed"]?.Value<int>() is { } blinkComment &&
+            arg.CommentAllowed > blinkComment)
+            arg.CommentAllowed = blinkComment;
+    }
+
+    /// <summary>Returns the larger of two possibly-null amounts (null is treated as "no bound").</summary>
+    private static LightMoney? Max(LightMoney? a, LightMoney? b)
+    {
+        if (a is null) return b;
+        if (b is null) return a;
+        return a > b ? a : b;
+    }
+
+    /// <summary>Returns the smaller of two possibly-null amounts (null is treated as "no bound").</summary>
+    private static LightMoney? Min(LightMoney? a, LightMoney? b)
+    {
+        if (a is null) return b;
+        if (b is null) return a;
+        return a < b ? a : b;
+    }
+}

--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkPlugin.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkPlugin.cs
@@ -21,6 +21,9 @@ namespace BTCPayServer.Plugins.Blink
             applicationBuilder.AddUIExtension("ln-payment-method-setup-tab", "Blink/LNPaymentMethodSetupTab");
             applicationBuilder.AddSingleton<ILightningConnectionStringHandler>(provider => provider.GetRequiredService<BlinkLightningConnectionStringHandler>());
             applicationBuilder.AddSingleton<BlinkLightningConnectionStringHandler>();
+            // Align served LNURL-pay metadata/bounds with Blink for non-custodial (ln-address) stores so
+            // strict wallets accept the Blink-minted invoice (LUD-06 description-hash commitment).
+            applicationBuilder.AddSingleton<Abstractions.Contracts.IPluginHookFilter, BlinkLnurlRequestFilter>();
 
             base.Execute(applicationBuilder);
         }

--- a/Plugins/BTCPayServer.Plugins.Blink/README.md
+++ b/Plugins/BTCPayServer.Plugins.Blink/README.md
@@ -46,6 +46,51 @@ type=blink;ln-address=yourname@blink.sv;
 Note: because there is no websocket for non-custodial accounts, payment detection uses polling of the
 LUD-21 verify URL. Settlement typically appears in BTCPay within a few seconds of payment.
 
+## Top-up / amountless invoices
+
+Top-up invoices (created with the amount left empty) are supported for both account types, but they
+work differently:
+
+- **Custodial (API key):** the plugin creates a true amountless BOLT11 invoice, so the checkout page
+  shows a normal Lightning invoice QR and the payer chooses the amount in their wallet.
+- **Lightning address (`ln-address=`):** LNURL-pay is inherently amount-driven, so an amountless
+  BOLT11 cannot be minted. Instead BTCPay falls back to the **LNURL** payment option, where the
+  payer's wallet supplies the amount and the plugin fetches a matching invoice from Blink. (This
+  applies to any `ln-address=` connection, including one pointing at a custodial Blink account.) For
+  this to work:
+
+  > **Custodial vs non-custodial lightning addresses.** The plugin auto-detects (via Blink's public
+  > API) whether an `ln-address=` points at a custodial Blink account or a non-custodial (Spark) one:
+  > - **Custodial**: fixed-amount invoices are minted directly through Blink's public GraphQL API,
+  >   committing to BTCPay's own description, so the payer's wallet shows the store description, and
+  >   settlement is detected even when a Blink-to-Blink payment settles internally (intraledger). This
+  >   avoids an issue where the Blink mobile app would pay a custodial lightning address intraledger
+  >   and bypass the BTCPay invoice, leaving the payment unregistered.
+  > - **Non-custodial (Spark)**: invoices are proxied from Blink's LNURL server; BTCPay mirrors Blink's
+  >   metadata so strict wallets accept the invoice (the payer's wallet then shows the Blink identity).
+
+  - the store's **LNURL** payment method must be enabled (it is by default when Lightning is set up);
+  - the payer's wallet shows the Blink identity line (e.g. *"Pay to yourname@blink.sv"*) instead of
+    the store description — this is unavoidable because the invoice's description hash is committed by
+    Blink's LNURL server;
+  - amounts must be whole satoshis and within Blink's per-address limits.
+
+  On a top-up invoice you will see a red event line in the invoice log such as *"BTC-LN: Payment
+  method unavailable (Blink lightning-address connections cannot create an amountless (top-up) bolt11
+  invoice...)"*. **This is expected and harmless** — it is just BTCPay recording that it fell back
+  from the plain BOLT11 method to LNURL. The invoice can still be paid via the LNURL QR.
+
+### Wallet compatibility for amountless invoices
+
+An amountless invoice has no amount encoded, so the paying wallet must let the user enter one. Most
+wallets (e.g. Phoenix) prompt for the amount and pay successfully. Some wallets do **not** support
+paying amountless BOLT11 invoices and will fail regardless of which lightning backend created the
+invoice — for example, in our testing the **Alby browser extension** could not pay them (see the
+long-standing amountless-invoice limitation tracked in
+[getAlby/lightning-browser-extension#823](https://github.com/getAlby/lightning-browser-extension/issues/823)).
+This is a wallet-side limitation, not a plugin issue. Use an amount-capable wallet, or a fixed-amount
+invoice, in that case.
+
 ## Migration: custodial → non-custodial
 
 If your Blink account is migrated from custodial to non-custodial, the existing BTCPay integration


### PR DESCRIPTION
## Summary

Fixes **top-up (amountless) invoice** support for the Blink plugin, reported in the BTCPay community Telegram after testing v1.1.0: paying a top-up invoice failed with the wallet reporting *"the lightning service is not available"*, while fixed-amount invoices worked. The fix covers all three Blink connection types and addresses three distinct root causes.

## Root causes & fixes

1. **API-key (custodial):** `CreateInvoice` always called the fixed-amount mutation, so a zero/null amount was rejected. It now routes amountless invoices to `lnNoAmountInvoiceCreateOnBehalfOfRecipient`, producing a real amountless BOLT11 at checkout (the payer enters the amount in their wallet).

2. **Lightning-address, non-custodial (Spark):** LNURL-pay is amount-driven, so an amountless BOLT11 can't be minted — BTCPay falls back to LNURL, where the payer picks the amount. But the Blink-minted invoice commits (its BOLT11 `h` tag) to *Blink's* LNURL metadata while BTCPay served *its own*, so LUD-06-strict wallets (Phoenix, Blitz) refused it. A new `modify-lnurlp-request` filter mirrors Blink's metadata and bounds for these stores so the description hash matches.

3. **Lightning-address, custodial:** mirroring the metadata (fix #2) exposes a `text/identifier`, which makes the **Blink mobile app pay the username intraledger and bypass the BTCPay invoice entirely** (payment never registered). The plugin now auto-detects custodial addresses via Blink's public (no-API-key) GraphQL API and, for them, mints invoices **directly** committing to BTCPay's own description hash — no mirroring, no bypass, store description restored — and detects settlement via the ledger-aware `lnInvoicePaymentStatusByHash` query (which also catches intraledger settlement). The filter skips metadata mirroring for custodial addresses using the same cached resolver, so client and filter always agree.

**Also fixes** an unrelated latent bug in the API-key client: it mapped Blink's `paymentSecret` (the BOLT11 `s` tag) to `Preimage`, failing BTCPay's `SHA256(preimage)==paymentHash` check and logging *"has a preimage but it doesn't match the payment hash"* on every payment. The preimage isn't returned at creation time, so it's left null.

## Behaviour by connection type (top-up invoices)

| Connection | Top-up behaviour | Payer sees |
|---|---|---|
| API-key (custodial) | Amountless BOLT11 minted directly | Store description |
| Lightning-address, custodial | Invoice minted via GraphQL, LNURL fallback for the amount | Store description |
| Lightning-address, Spark (non-custodial) | LNURL fallback, Blink metadata mirrored | Blink identity (`Pay to user@blink.sv`) |

Non-custodial (Spark) behaviour is otherwise unchanged (LNURL proxy + LUD-21 verify).

## Testing

- **117 unit tests** pass (adds coverage for account-type detection, GraphQL response parsing incl. the `{"data":null,...}` shape, description-hash computation, and the LNURL filter's mirror/skip + bounds-intersection logic).
- **Live mainnet test matrix** — fixed / top-up × api-key / custodial-ln-address / spark-ln-address × Blink-app (intraledger) / Phoenix — all invoices settled and registered in BTCPay, including the previously-broken custodial-ln-address-paid-from-Blink-app case.

## Notes

- Known wallet-side limitation documented in the README: the **Alby browser extension** cannot pay amountless BOLT11 invoices ([getAlby/lightning-browser-extension#823](https://github.com/getAlby/lightning-browser-extension/issues/823)) — this affects any BTCPay lightning backend, not just Blink.
- Only the public, no-API-key Blink operations are used for the ln-address paths (`accountDefaultWallet`, `lnInvoiceCreateOnBehalfOfRecipient` / `lnNoAmountInvoiceCreateOnBehalfOfRecipient`, `lnInvoicePaymentStatusByHash`), per Blink's documented no-key operation list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custodial Blink invoice creation and payment-status tracking.
  * Added support for amountless/top-up invoices, including LNURL-pay fallback where applicable.
  * Improved Blink Lightning address compatibility by aligning payment limits, comments, and metadata.
  * Added safer handling of Blink account resolution and invoice errors.

* **Bug Fixes**
  * Corrected payment-secret handling to avoid incorrect preimage reporting.
  * Improved handling of invalid, expired, and unknown invoices.

* **Documentation**
  * Documented amountless invoices, account modes, wallet compatibility, and supported limits.

* **Chores**
  * Updated the plugin version to 1.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->