### PR TITLE
NWC: use nip44 encryption — fixes missing payment notifications with nip44-only wallets

### DIFF
--- a/Plugins/BTCPayServer.Plugins.NIP05/BTCPayServer.Plugins.NIP05.csproj
+++ b/Plugins/BTCPayServer.Plugins.NIP05/BTCPayServer.Plugins.NIP05.csproj
@@ -36,7 +36,7 @@
         <ProjectReference Include="..\..\submodules\btcpayserver\BTCPayServer\BTCPayServer.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="NNostr.Client" Version="0.0.54" />
+      <PackageReference Include="NNostr.Client" Version="0.0.55" />
     </ItemGroup>
     <ItemGroup>
       <Folder Include="Resources" />

--- a/Plugins/BTCPayServer.Plugins.NIP05/NostrWalletConnectLightningClient.cs
+++ b/Plugins/BTCPayServer.Plugins.NIP05/NostrWalletConnectLightningClient.cs
@@ -11,6 +11,7 @@ using BTCPayServer.Lightning;
 using BTCPayServer.Payments.Lightning;
 using NBitcoin;
 using NBitcoin.Secp256k1;
+using Microsoft.Extensions.Logging;
 using NNostr.Client;
 using NNostr.Client.Protocols;
 using SHA256 = System.Security.Cryptography.SHA256;
@@ -32,11 +33,15 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
     private readonly (ECXOnlyPubKey pubkey, ECPrivKey secret, Uri[] relays, string lud16) _connectParams;
 	private readonly Uri? _serverUri;
 
-	public NostrWalletConnectLightningClient(NostrClientPool nostrClientPool, Uri uri, Network network)
+	private readonly ILogger<NostrWalletConnectLightningClient>? _logger;
+
+	public NostrWalletConnectLightningClient(NostrClientPool nostrClientPool, Uri uri, Network network,
+        ILogger<NostrWalletConnectLightningClient>? logger = null)
     {
         _nostrClientPool = nostrClientPool;
         _uri = uri;
         _network = network;
+        _logger = logger;
         _connectParams = NIP47.ParseUri(uri);
         _serverUri = _connectParams.relays.FirstOrDefault();
     }
@@ -60,6 +65,8 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
             ? NIP47.EncryptionScheme.Nip44V2
             : NIP47.EncryptionScheme.Nip04;
         _encryptionScheme = scheme;
+        _logger?.LogInformation("NWC: negotiated {Scheme} encryption with wallet service on {Relay} (advertised: {Advertised})",
+            scheme, _serverUri, info?.EncryptionSchemes is { Length: > 0 } s ? string.Join(" ", s) : "(no encryption tag)");
         return scheme;
     }
 
@@ -286,6 +293,8 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
             var response = await x.Item1.SendNIP47Request<NIP47.GetInfoResponse>(_connectParams.pubkey, _connectParams.secret, new NIP47.GetInfoRequest(), cancellationToken: cancellation, encryptionScheme: scheme);
 			hasNotification = response?.Notifications?.Contains("payment_received");
 		}
+        _logger?.LogInformation("NWC: listening for paid invoices via {Listener} ({Scheme}, payment_received supported: {HasNotification})",
+            hasNotification is true ? "push notifications" : "polling", scheme, hasNotification ?? false);
         return hasNotification is true
 			? new NotificationListener(_network, x, _connectParams, scheme)
             : new PollListener(_network, x, _connectParams, scheme);

--- a/Plugins/BTCPayServer.Plugins.NIP05/NostrWalletConnectLightningClient.cs
+++ b/Plugins/BTCPayServer.Plugins.NIP05/NostrWalletConnectLightningClient.cs
@@ -46,6 +46,23 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
         return $"type=nwc;key={_uri}";
     }
 
+    private NIP47.EncryptionScheme? _encryptionScheme;
+
+    // NIP-47: the wallet service advertises supported encryption schemes via the "encryption"
+    // tag on its kind-13194 info event. Prefer nip44_v2 when available, otherwise fall back
+    // to nip04 (absence of the tag means the wallet only supports nip04).
+    private async Task<NIP47.EncryptionScheme> GetEncryptionScheme(INostrClient client, CancellationToken cancellationToken)
+    {
+        if (_encryptionScheme is { } cached)
+            return cached;
+        var info = await client.FetchNIP47InfoEvent(_connectParams.pubkey, cancellationToken);
+        var scheme = info?.EncryptionSchemes?.Contains(NIP47.EncryptionSchemeNip44V2) is true
+            ? NIP47.EncryptionScheme.Nip44V2
+            : NIP47.EncryptionScheme.Nip04;
+        _encryptionScheme = scheme;
+        return scheme;
+    }
+
 
     public async Task<LightningInvoice> GetInvoice(string invoiceId,
         CancellationToken cancellation = new())
@@ -94,12 +111,13 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
 
         using (usage)
         {
+            var scheme = await GetEncryptionScheme(nostrClient, cts.Token);
             var tx = await nostrClient.SendNIP47Request<NIP47.Nip47Transaction>(_connectParams.pubkey,
                 _connectParams.secret,
                 new NIP47.LookupInvoiceRequest()
                 {
                     PaymentHash = paymentHash.ToString()
-                }, cts.Token);
+                }, cts.Token, scheme);
             return ToLightningInvoice(tx, _network)!;
         }
     }
@@ -118,6 +136,7 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
         var (client, usage) = await _nostrClientPool.GetClientAndConnect(_connectParams.relays, cts.Token);
         using (usage)
         {
+            var scheme = await GetEncryptionScheme(client, cts.Token);
             var response = await client.SendNIP47Request<NIP47.ListTransactionsResponse>(_connectParams.pubkey,
                 _connectParams.secret,
                 new NIP47.ListTransactionsRequest()
@@ -125,7 +144,7 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
                     Type = "incoming",
                     Offset = (int)(request.OffsetIndex ?? 0),
                     Unpaid = request.PendingOnly ?? false,
-                }, cts.Token);
+                }, cts.Token, scheme);
 
             return response.Transactions.Select(transaction => ToLightningInvoice(transaction, _network))
                 .Where(i => i is not null).ToArray()!;
@@ -177,11 +196,12 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
             NIP47.Nip47Transaction tx;
             try
             {
+                var scheme = await GetEncryptionScheme(nostrClient, cts.Token);
                 tx = await nostrClient.SendNIP47Request<NIP47.Nip47Transaction>(_connectParams.pubkey, _connectParams.secret,
                     new NIP47.LookupInvoiceRequest()
                     {
                         PaymentHash = paymentHash
-                    }, cts.Token);
+                    }, cts.Token, scheme);
             }
             // The standard says it returns NOT_FOUND error, but
             // Alby returns INTERNAL error... Probably safer to catch all
@@ -207,6 +227,7 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
 
         using (usage)
         {
+            var scheme = await GetEncryptionScheme(nostrClient, cts.Token);
             var response = await nostrClient.SendNIP47Request<NIP47.ListTransactionsResponse>(_connectParams.pubkey,
                 _connectParams.secret,
                 new NIP47.ListTransactionsRequest()
@@ -214,7 +235,7 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
                     Type = "outgoing",
                     Offset = (int)(request.OffsetIndex ?? 0),
                     Unpaid = request.IncludePending ?? false,
-                }, cts.Token);
+                }, cts.Token, scheme);
             return response.Transactions.Select(ToLightningPayment).Where(i => i is not null).ToArray()!;
         }
     }
@@ -235,6 +256,7 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
 
         using (usage)
         {
+            var scheme = await GetEncryptionScheme(nostrClient, cts.Token);
             var response = await nostrClient.SendNIP47Request<NIP47.Nip47Transaction>(_connectParams.pubkey,
                 _connectParams.secret,
                 new NIP47.MakeInvoiceRequest()
@@ -245,7 +267,7 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
                         : createInvoiceRequest.Description,
                     DescriptionHash = createInvoiceRequest.DescriptionHash?.ToString(),
                     ExpirySeconds = (int)createInvoiceRequest.Expiry.TotalSeconds,
-                }, cts.Token);
+                }, cts.Token, scheme);
             return ToLightningInvoice(response, _network)!;
         }
     }
@@ -253,16 +275,20 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
     public async Task<ILightningInvoiceListener> Listen(CancellationToken cancellation = default)
     {
         var x = await _nostrClientPool.GetClientAndConnect(_connectParams.relays, cancellation);
-		var commands = await x.Item1.FetchNIP47AvailableCommands(_connectParams.Item1, cancellationToken: cancellation);
-        bool? hasNotification = commands?.Notifications?.Contains("payment_received");
+		var info = await x.Item1.FetchNIP47InfoEvent(_connectParams.Item1, cancellationToken: cancellation);
+        var scheme = info?.EncryptionSchemes?.Contains(NIP47.EncryptionSchemeNip44V2) is true
+            ? NIP47.EncryptionScheme.Nip44V2
+            : NIP47.EncryptionScheme.Nip04;
+        _encryptionScheme = scheme;
+        bool? hasNotification = info?.Notifications?.Contains("payment_received");
         if (hasNotification is false)
         {
-            var response = await x.Item1.SendNIP47Request<NIP47.GetInfoResponse>(_connectParams.pubkey, _connectParams.secret, new NIP47.GetInfoRequest(), cancellationToken: cancellation);
+            var response = await x.Item1.SendNIP47Request<NIP47.GetInfoResponse>(_connectParams.pubkey, _connectParams.secret, new NIP47.GetInfoRequest(), cancellationToken: cancellation, encryptionScheme: scheme);
 			hasNotification = response?.Notifications?.Contains("payment_received");
 		}
         return hasNotification is true
-			? new NotificationListener(_network, x, _connectParams)
-            : new PollListener(_network, x, _connectParams);
+			? new NotificationListener(_network, x, _connectParams, scheme)
+            : new PollListener(_network, x, _connectParams, scheme);
     }
 
 
@@ -276,13 +302,14 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
         private readonly IDisposable _disposable;
 
         public NotificationListener(Network network, (INostrClient, IDisposable) client,
-            (ECXOnlyPubKey pubkey, ECPrivKey secret, Uri[] relays, string lud16) x)
+            (ECXOnlyPubKey pubkey, ECPrivKey secret, Uri[] relays, string lud16) x,
+            NIP47.EncryptionScheme encryptionScheme)
         {
             _network = network;
             _client = client.Item1;
             _disposable = client.Item2;
             _cts = new CancellationTokenSource();
-            _notifications = _client.SubscribeNip47Notifications(x.pubkey, x.secret, _cts.Token);
+            _notifications = _client.SubscribeNip47Notifications(x.pubkey, x.secret, _cts.Token, encryptionScheme);
         }
 
         public void Dispose()
@@ -319,13 +346,17 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
         private NIP47.ListTransactionsResponse? _lastPaid;
         private Channel<LightningInvoice> queue = Channel.CreateUnbounded<LightningInvoice>();
 
+        private readonly NIP47.EncryptionScheme _encryptionScheme;
+
         public PollListener(Network network, (INostrClient, IDisposable) client,
-            (ECXOnlyPubKey pubkey, ECPrivKey secret, Uri[] relays, string lud16) connectparams)
+            (ECXOnlyPubKey pubkey, ECPrivKey secret, Uri[] relays, string lud16) connectparams,
+            NIP47.EncryptionScheme encryptionScheme)
         {
             _network = network;
             _connectparams = connectparams;
             _client = client.Item1;
             _disposable = client.Item2;
+            _encryptionScheme = encryptionScheme;
             _cts = new CancellationTokenSource();
             _ = Poll();
         }
@@ -343,9 +374,9 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
                         _connectparams.secret, new NIP47.ListTransactionsRequest()
                         {
                             Type = "incoming",
-                            // Unpaid = true, //seems like this is ignored... so we only get paid ones 
+                            // Unpaid = true, //seems like this is ignored... so we only get paid ones
                             Limit = 300
-                        }, cancellationToken: cts.Token);
+                        }, cancellationToken: cts.Token, encryptionScheme: _encryptionScheme);
                     paid.Transactions = paid.Transactions.Where(i => i is { Type: "incoming", SettledAt: not null }).ToArray();
                     if (_lastPaid is not null)
                     {
@@ -402,9 +433,10 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
 
         using (usage)
         {
+            var scheme = await GetEncryptionScheme(client, cts.Token);
             var response = await client.SendNIP47Request<NIP47.GetBalanceResponse>(_connectParams.pubkey,
                 _connectParams.secret,
-                new NIP47.NIP47Request("get_balance"), cts.Token);
+                new NIP47.NIP47Request("get_balance"), cts.Token, scheme);
             return new LightningNodeBalance()
             {
                 OffchainBalance = new OffchainBalance()
@@ -456,7 +488,8 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
                 };
 
             }
-            var response = await client.SendNIP47Request<NIP47.PayInvoiceResponse>(_connectParams.pubkey, _connectParams.secret, request, cts.Token);
+            var scheme = await GetEncryptionScheme(client, cts.Token);
+            var response = await client.SendNIP47Request<NIP47.PayInvoiceResponse>(_connectParams.pubkey, _connectParams.secret, request, cts.Token, scheme);
             var payHash = ConvertHelper.ToHexString(SHA256.HashData(Convert.FromHexString(response.Preimage)));
 
             try
@@ -465,7 +498,7 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
                     new NIP47.LookupInvoiceRequest()
                     {
                         PaymentHash = payHash
-                    }, cts.Token);
+                    }, cts.Token, scheme);
                 var lp = ToLightningPayment(tx)!;
                 return new PayResponse(lp.Status == LightningPaymentStatus.Complete ? PayResult.Ok : PayResult.Error,
                     new PayDetails()
@@ -530,16 +563,21 @@ public class NostrWalletConnectLightningClient : IExtendedLightningClient
 		var (client, disposable) = await _nostrClientPool.GetClientAndConnect(_connectParams.relays, cts.Token).ConfigureAwait(false);
         using (disposable)
         {
-			var commands = await client.FetchNIP47AvailableCommands(_connectParams.Item1, cancellationToken: cts.Token);
+			var info = await client.FetchNIP47InfoEvent(_connectParams.Item1, cancellationToken: cts.Token);
 			var requiredCommands = new[] { "get_info", "make_invoice", "lookup_invoice", "list_transactions" };
-			if (commands?.Commands is null || requiredCommands.Any(c => !commands.Value.Commands.Contains(c)))
+			if (info?.Commands is null || requiredCommands.Any(c => !info.Value.Commands.Contains(c)))
 			{
 				return new ValidationResult("No commands available or not all required commands are available (get_info, make_invoice, lookup_invoice, list_transactions)");
 			}
 
+			var scheme = info.Value.EncryptionSchemes?.Contains(NIP47.EncryptionSchemeNip44V2) is true
+				? NIP47.EncryptionScheme.Nip44V2
+				: NIP47.EncryptionScheme.Nip04;
+			_encryptionScheme = scheme;
+
 			var response = await client
 					.SendNIP47Request<NIP47.GetInfoResponse>(_connectParams.pubkey, _connectParams.secret,
-						new NIP47.GetInfoRequest(), cancellationToken: cts.Token);
+						new NIP47.GetInfoRequest(), cancellationToken: cts.Token, encryptionScheme: scheme);
 
 			var walletNetwork = response.Network;
 			if (!_network.ChainName.ToString().Equals(walletNetwork,

--- a/Plugins/BTCPayServer.Plugins.NIP05/NostrWalletConnectLightningConnectionStringHandler.cs
+++ b/Plugins/BTCPayServer.Plugins.NIP05/NostrWalletConnectLightningConnectionStringHandler.cs
@@ -12,10 +12,13 @@ namespace BTCPayServer.Plugins.NIP05;
 public class NostrWalletConnectLightningConnectionStringHandler : ILightningConnectionStringHandler
 {
     private readonly NostrClientPool _nostrClientPool;
+    private readonly Microsoft.Extensions.Logging.ILogger<NostrWalletConnectLightningClient> _logger;
 
-    public NostrWalletConnectLightningConnectionStringHandler(NostrClientPool nostrClientPool)
+    public NostrWalletConnectLightningConnectionStringHandler(NostrClientPool nostrClientPool,
+        Microsoft.Extensions.Logging.ILogger<NostrWalletConnectLightningClient> logger)
     {
         _nostrClientPool = nostrClientPool;
+        _logger = logger;
     }
     public ILightningClient? Create(string connectionString, Network network, out string? error)
     {
@@ -41,6 +44,6 @@ public class NostrWalletConnectLightningConnectionStringHandler : ILightningConn
         }
 
         error = null;
-		return new NostrWalletConnectLightningClient(_nostrClientPool, uri, network);
+		return new NostrWalletConnectLightningClient(_nostrClientPool, uri, network, _logger);
 	}
 }


### PR DESCRIPTION
Users connecting rizful.com wallets via Nostr Wallet Connect reported that payments arrive but BTCPay never shows "payment received". The cause: rizful's wallet service only supports the current [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) encryption, while the plugin still talks the deprecated NIP-04 — so its payment notifications are never received.

With this change the plugin reads what encryption the wallet service advertises and uses nip44 whenever available. A connection sticks to a single scheme — when nip44 is supported it is used **exclusively**, never mixed with nip04, since sending both would defeat the security purpose of nip44. Older wallets that don't advertise nip44 keep working over nip04 exactly as before, and existing connections need no settings change.

The server log now shows which encryption was negotiated and whether paid invoices are detected via push notifications or polling, which helps troubleshooting connection issues like this one.

Tested end-to-end on a mainnet BTCPay 2.4.2 instance with both rizful.com (nip44-only — unusable before this change) and Alby: connection validation, invoice creation, and payment settlement detected via nip44 push notifications (kind 23197). Works great on both.

**Draft**: depends on NNostr nip44 support (<link to NNostr PR>) and needs an `NNostr.Client` release containing it; the `PackageReference` here still points at 0.0.54, so CI will fail to compile until that version bump. I'll update the reference and mark this ready once the package is out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for negotiating NIP-44 v2 encryption with compatible wallets.
  * Automatically falls back to NIP-04 encryption when NIP-44 v2 is unavailable.
  * Applies the selected encryption method to wallet requests and notification subscriptions.
  * Caches the negotiated encryption method for continued wallet communication.

* **Bug Fixes**
  * Improved wallet validation by checking supported commands before completing setup.
  * Added clearer logging for encryption mode and notification support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->