### PR TITLE
Blink: fix runaway LUD-21 verify polling

### DIFF
--- a/BTCPayServer.Plugins.Blink.Tests/BlinkLnAddressLogicTests.cs
+++ b/BTCPayServer.Plugins.Blink.Tests/BlinkLnAddressLogicTests.cs
@@ -120,13 +120,15 @@ public class BlinkLnAddressLogicTests
         var poll = TimeSpan.FromSeconds(3);
         var max = TimeSpan.FromSeconds(30);
 
+        // Delays carry ±20% jitter, so assert the incremented error count exactly and the delay
+        // within the jitter band around the base (3 * 2^errors).
         var (e1, d1) = BlinkLnAddressLightningClient.NextBackoff(0, poll, max);
         Assert.Equal(1, e1);
-        Assert.Equal(TimeSpan.FromSeconds(6), d1); // 3 * 2^1
+        AssertWithinJitter(TimeSpan.FromSeconds(6), d1); // 3 * 2^1
 
         var (e2, d2) = BlinkLnAddressLightningClient.NextBackoff(1, poll, max);
         Assert.Equal(2, e2);
-        Assert.Equal(TimeSpan.FromSeconds(12), d2); // 3 * 2^2
+        AssertWithinJitter(TimeSpan.FromSeconds(12), d2); // 3 * 2^2
     }
 
     [Fact]
@@ -136,7 +138,63 @@ public class BlinkLnAddressLogicTests
         var max = TimeSpan.FromSeconds(30);
         var (errors, delay) = BlinkLnAddressLightningClient.NextBackoff(10, poll, max);
         Assert.Equal(11, errors);
-        Assert.Equal(max, delay);
+        // The base delay is capped at max BEFORE jitter, so the result is within ±20% of max.
+        AssertWithinJitter(max, delay);
+    }
+
+    // ±20% jitter band (with a tiny epsilon for floating-point rounding).
+    private static void AssertWithinJitter(TimeSpan baseline, TimeSpan actual)
+    {
+        var lo = baseline.TotalMilliseconds * 0.8 - 1;
+        var hi = baseline.TotalMilliseconds * 1.2 + 1;
+        Assert.InRange(actual.TotalMilliseconds, lo, hi);
+    }
+
+    [Fact]
+    public void ApplyJitter_stays_within_plus_minus_20_percent()
+    {
+        // Sample many draws; every result must be inside [0.8x, 1.2x] and not always identical.
+        const double baseMs = 10_000;
+        bool sawBelow = false, sawAbove = false;
+        for (var i = 0; i < 2000; i++)
+        {
+            var v = BlinkLnAddressLightningClient.ApplyJitter(baseMs);
+            Assert.InRange(v, baseMs * 0.8, baseMs * 1.2);
+            if (v < baseMs) sawBelow = true;
+            if (v > baseMs) sawAbove = true;
+        }
+        Assert.True(sawBelow && sawAbove, "jitter should vary both below and above the base delay");
+    }
+
+    [Fact]
+    public void ApplyJitter_never_below_one_ms()
+    {
+        Assert.True(BlinkLnAddressLightningClient.ApplyJitter(0) >= 1.0);
+    }
+
+    // ---- Age-stepped poll interval (F3) ----
+
+    [Theory]
+    [InlineData(0, 3)]      // fresh
+    [InlineData(60, 3)]     // < 2 min
+    [InlineData(119, 3)]    // just under 2 min
+    [InlineData(120, 10)]   // 2 min boundary -> 10s
+    [InlineData(300, 10)]   // < 10 min
+    [InlineData(599, 10)]   // just under 10 min
+    [InlineData(600, 30)]   // 10 min boundary -> 30s
+    [InlineData(3600, 30)]  // long-lived
+    public void MinIntervalForAge_steps_with_age(int ageSeconds, int expectedSeconds)
+    {
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds),
+            BlinkLnAddressLightningClient.MinIntervalForAge(TimeSpan.FromSeconds(ageSeconds)));
+    }
+
+    // ---- User-Agent (attribution) ----
+
+    [Fact]
+    public void UserAgent_identifies_the_plugin()
+    {
+        Assert.StartsWith("BTCPayServer.Plugins.Blink/", BlinkLnAddressLightningClient.UserAgent);
     }
 
     // ---- Lightning-address parsing ----

--- a/Plugins/BTCPayServer.Plugins.Blink/BlinkLnAddressLightningClient.cs
+++ b/Plugins/BTCPayServer.Plugins.Blink/BlinkLnAddressLightningClient.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Net.Http;
@@ -42,7 +43,12 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
     private readonly HttpClient _httpClient;
     private readonly ILogger _logger;
 
-    private record TrackedInvoice(string Bolt11, string? VerifyUrl, DateTimeOffset ExpiresAt);
+    private record TrackedInvoice(string Bolt11, string? VerifyUrl, DateTimeOffset ExpiresAt)
+    {
+        // When the invoice was first tracked locally. Drives the age-stepped poll interval (F3):
+        // fresh invoices poll fast for quick settlement feedback, long-lived unpaid ones back off.
+        public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
+    }
 
     // BTCPay creates SEPARATE client instances for creating invoices and for its payment
     // listener/poller. In-memory per-instance state would therefore not be visible to the listener.
@@ -88,7 +94,17 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
         _network = network;
         _httpClient = httpClient;
         _logger = logger;
+
+        // Identify plugin verify/LNURL traffic so operators can attribute it in server telemetry
+        // (and so the path-scoped rate limit can be tuned per client type). Multiple client
+        // instances may share one HttpClient, so only set the UA if not already present.
+        if (!_httpClient.DefaultRequestHeaders.UserAgent.Any())
+            _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent);
     }
+
+    /// <summary>Product-info User-Agent header value identifying this plugin (name/version).</summary>
+    internal static string UserAgent =>
+        $"BTCPayServer.Plugins.Blink/{typeof(BlinkLnAddressLightningClient).Assembly.GetName().Version}";
 
     /// <summary>Splits a "user@domain" lightning address into its parts, throwing on an invalid address.</summary>
     internal static (string Username, string Domain) ParseLightningAddress(string lightningAddress)
@@ -299,15 +315,65 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
     }
 
     /// <summary>Computes the next per-invoice back-off after a verify failure:
-    /// delay = min(pollInterval * 2^errors, maxBackoff). Returns the incremented error count and delay.</summary>
+    /// delay = min(pollInterval * 2^errors, maxBackoff), with ±20% jitter to avoid lockstep retries
+    /// when many invoices fail against the same degraded verify endpoint at once (F5).
+    /// Returns the incremented error count and delay.</summary>
     internal static (int Errors, TimeSpan Delay) NextBackoff(int previousErrors, TimeSpan pollInterval, TimeSpan maxBackoff)
     {
         var errors = previousErrors + 1;
         var delayMs = Math.Min(pollInterval.TotalMilliseconds * Math.Pow(2, errors), maxBackoff.TotalMilliseconds);
+        delayMs = ApplyJitter(delayMs);
         return (errors, TimeSpan.FromMilliseconds(delayMs));
     }
 
+    /// <summary>Applies ±20% random jitter to a delay (milliseconds), never below 1ms.</summary>
+    internal static double ApplyJitter(double delayMs)
+    {
+        var jitter = 1.0 + (Random.Shared.NextDouble() * 0.4 - 0.2); // [0.8, 1.2)
+        return Math.Max(1.0, delayMs * jitter);
+    }
+
+    /// <summary>Age-stepped minimum poll interval for a tracked invoice (F3): poll fresh invoices
+    /// fast for quick settlement feedback, then back off as the invoice ages so a long-lived unpaid
+    /// invoice is not hammered every few seconds for its whole expiry window.</summary>
+    internal static TimeSpan MinIntervalForAge(TimeSpan age)
+        => age < TimeSpan.FromMinutes(2) ? TimeSpan.FromSeconds(3)
+         : age < TimeSpan.FromMinutes(10) ? TimeSpan.FromSeconds(10)
+         : TimeSpan.FromSeconds(30);
+
+    /// <summary>The outcome of a single LUD-21 verify poll, so the poll loop can distinguish a real
+    /// invoice status from a transport/HTTP failure (which must trigger back-off) and from an explicit
+    /// "not found" (which, after confirmation, should evict the invoice) — without conflating them.</summary>
+    internal enum VerifyOutcome
+    {
+        /// <summary>verify returned a usable status (settled/unpaid/expired).</summary>
+        Status,
+        /// <summary>HTTP error / timeout / unparseable body. Transient — the poller should back off.</summary>
+        TransportError,
+        /// <summary>verify explicitly returned status=ERROR (the server has no such invoice).</summary>
+        NotFound,
+    }
+
     public async Task<LightningInvoice?> GetInvoice(string invoiceId, CancellationToken cancellation = new())
+    {
+        var (outcome, invoice) = await PollVerify(invoiceId, cancellation);
+
+        // BTCPay's poller drops an invoice from monitoring when GetInvoice returns null, and it only
+        // re-seeds monitored invoices on restart. So for a transient transport error we must NOT return
+        // null; return a minimal Unpaid so the invoice stays tracked and is retried. (BTCPay
+        // short-circuits Unpaid before reading amount/bolt11 fields, so this is safe.)
+        if (outcome == VerifyOutcome.TransportError && invoice is null)
+            return new LightningInvoice { Id = invoiceId, PaymentHash = invoiceId, Status = LightningInvoiceStatus.Unpaid };
+
+        // NotFound => return null so BTCPay stops monitoring this invoice.
+        return invoice;
+    }
+
+    /// <summary>Polls the LUD-21 verify URL for an invoice and reports the outcome. On TransportError the
+    /// returned invoice may be null (no cached bolt11) or a synthetic Unpaid; on NotFound it is null; on
+    /// Status it is the built invoice. Shared by GetInvoice and the settlement poll loop.</summary>
+    internal async Task<(VerifyOutcome Outcome, LightningInvoice? Invoice)> PollVerify(
+        string invoiceId, CancellationToken cancellation = new())
     {
         _tracked.TryGetValue(invoiceId, out var tracked);
 
@@ -337,37 +403,34 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
         }
 
         // Explicit "not found" from the verify endpoint => the invoice genuinely does not exist.
-        // Only in that case do we return null (BTCPay will stop tracking it).
         if (json?["status"]?.Value<string>()?.Equals("ERROR", StringComparison.OrdinalIgnoreCase) == true)
         {
             _logger.LogDebug("Blink verify returned ERROR for {PaymentHash}: {Reason}", invoiceId,
                 json["reason"]?.Value<string>());
-            return null;
+            return (VerifyOutcome.NotFound, null);
         }
 
         var pr = tracked?.Bolt11 ?? json?["pr"]?.Value<string>();
         if (pr is null)
         {
-            // Transient transport error on a fresh client (no cached bolt11). Do NOT return null:
-            // BTCPay's poller drops an invoice from monitoring when GetInvoice returns null, and it
-            // only re-seeds monitored invoices on restart. Instead return a minimal Unpaid invoice so
-            // the invoice stays tracked and is retried. (BTCPay short-circuits Unpaid before reading
-            // amount/bolt11 fields, so this is safe.)
-            if (transportError)
-                return new LightningInvoice
-                {
-                    Id = invoiceId,
-                    PaymentHash = invoiceId,
-                    Status = LightningInvoiceStatus.Unpaid
-                };
-            return null;
+            // No usable bolt11. On a transport error there is no status to report (invoice stays
+            // tracked); on a 2xx with no pr and no cached bolt11 there is nothing to build.
+            return transportError
+                ? (VerifyOutcome.TransportError, null)
+                : (VerifyOutcome.NotFound, null);
         }
+
+        if (transportError)
+            return (VerifyOutcome.TransportError, null);
 
         var settled = json?["settled"]?.Value<bool>() ?? false;
         var preimage = json?["preimage"]?.Value<string>();
         var expiresAt = tracked?.ExpiresAt ?? BOLT11PaymentRequest.Parse(pr, _network).ExpiryDate;
-        var t = new TrackedInvoice(pr, verifyUrl, expiresAt);
-        return BuildInvoice(invoiceId, t, settled, preimage);
+        var t = new TrackedInvoice(pr, verifyUrl, expiresAt)
+        {
+            CreatedAt = tracked?.CreatedAt ?? DateTimeOffset.UtcNow
+        };
+        return (VerifyOutcome.Status, BuildInvoice(invoiceId, t, settled, preimage));
     }
 
     private LightningInvoice BuildInvoice(string paymentHash, TrackedInvoice tracked, bool settled, string? preimage)
@@ -449,34 +512,94 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
 
     public async Task<ILightningInvoiceListener> Listen(CancellationToken cancellation = new())
     {
-        return new BlinkLnAddressListener(this, _logger);
+        // F4: a single shared poll loop per lightning address, ref-counted across all listeners.
+        // Previously every Listen() spawned an independent PollLoop over the same shared registry,
+        // multiplying the /verify/* request rate by the number of live listeners.
+        var poller = SharedVerifyPoller.Acquire(_lightningAddress, this, _logger);
+        return new BlinkLnAddressListener(poller);
     }
 
     /// <summary>
-    /// Polls the LUD-21 verify URLs of tracked, unpaid invoices and yields them as they settle.
-    /// Spark settlement is delivered to blink-lnurl-server via an SSP webhook, so detection may lag
-    /// the actual payment by a few seconds; there is no websocket for non-custodial accounts.
+    /// One shared verify-polling loop per lightning address (static registry, ref-counted). Polls the
+    /// LUD-21 verify URLs of tracked, unpaid invoices and broadcasts settlements to all listeners.
+    ///
+    /// Fixes vs. the previous per-listener loop:
+    ///  - F1: transport/HTTP errors trigger capped exponential back-off (they are no longer swallowed
+    ///        and mistaken for success), so a degraded blink-lnurl-server is not hammered.
+    ///  - F2: invoices the server reports as not-found are evicted after a few confirmations instead of
+    ///        being polled forever.
+    ///  - F3: the per-invoice poll interval widens as the invoice ages (fresh = fast, stale = slow).
+    ///  - F4: one loop per address regardless of how many times Listen() is called.
+    ///
+    /// Spark settlement is delivered to blink-lnurl-server via an SSP webhook, so detection may lag the
+    /// actual payment by a few seconds; there is no websocket for non-custodial accounts.
     /// </summary>
-    public class BlinkLnAddressListener : ILightningInvoiceListener
+    public sealed class SharedVerifyPoller
     {
         private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(3);
         private static readonly TimeSpan MaxBackoff = TimeSpan.FromSeconds(30);
+
+        // Evict an invoice only after this many consecutive not-found (status=ERROR) responses, to
+        // tolerate the brief race between invoice creation and the invoice becoming visible to verify.
+        internal const int NotFoundEvictionThreshold = 3;
+
+        private static readonly ConcurrentDictionary<string, SharedVerifyPoller> _byAddress = new();
+
+        private readonly string _address;
         private readonly BlinkLnAddressLightningClient _client;
         private readonly ILogger _logger;
-        private readonly Channel<LightningInvoice> _channel = Channel.CreateUnbounded<LightningInvoice>();
         private readonly CancellationTokenSource _cts = new();
         private readonly Task _pollTask;
+        private int _refCount;
 
-        // Per-invoice error back-off: number of consecutive failures and the earliest next attempt.
-        private readonly System.Collections.Generic.Dictionary<string, (int Errors, DateTimeOffset NextAttempt)>
-            _backoff = new();
+        // Per-invoice poll scheduling: consecutive transport errors, consecutive not-founds, and the
+        // earliest next attempt (covers both error back-off and the age-stepped steady-state interval).
+        private readonly System.Collections.Generic.Dictionary<string, InvoicePollState> _state = new();
 
-        public BlinkLnAddressListener(BlinkLnAddressLightningClient client, ILogger logger)
+        private sealed class InvoicePollState
         {
+            public int Errors;
+            public int NotFounds;
+            public DateTimeOffset NextAttempt;
+        }
+
+        /// <summary>Raised when the poller observes an invoice settle. Listeners filter to their own.</summary>
+        public event Action<LightningInvoice>? Settled;
+
+        private SharedVerifyPoller(string address, BlinkLnAddressLightningClient client, ILogger logger)
+        {
+            _address = address;
             _client = client;
             _logger = logger;
             _pollTask = Task.Run(() => PollLoop(_cts.Token));
         }
+
+        /// <summary>Returns the shared poller for the address, creating and starting it on first use.</summary>
+        public static SharedVerifyPoller Acquire(string address, BlinkLnAddressLightningClient client, ILogger logger)
+        {
+            return _byAddress.AddOrUpdate(
+                address,
+                _ => { var p = new SharedVerifyPoller(address, client, logger); p._refCount = 1; return p; },
+                (_, existing) => { Interlocked.Increment(ref existing._refCount); return existing; });
+        }
+
+        /// <summary>Releases a listener's hold; stops and unregisters the loop when the last one leaves.</summary>
+        public void Release()
+        {
+            if (Interlocked.Decrement(ref _refCount) > 0)
+                return;
+            _byAddress.TryRemove(_address, out _);
+            _cts.Cancel();
+            try { _pollTask.Wait(TimeSpan.FromSeconds(5)); }
+            catch { /* cancellation / bounded wait */ }
+            _cts.Dispose();
+        }
+
+        /// <summary>Number of live listeners holding this poller (exposed for tests).</summary>
+        internal int RefCount => Volatile.Read(ref _refCount);
+
+        /// <summary>How many shared pollers currently exist across all addresses (exposed for tests).</summary>
+        internal static int ActivePollerCount => _byAddress.Count;
 
         private async Task PollLoop(CancellationToken cancellation)
         {
@@ -490,24 +613,66 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
                         cancellation.ThrowIfCancellationRequested();
                         var (paymentHash, tracked) = (kv.Key, kv.Value);
 
-                        // Skip this invoice while it is backing off after repeated failures.
-                        if (_backoff.TryGetValue(paymentHash, out var b) && now < b.NextAttempt)
+                        var st = _state.TryGetValue(paymentHash, out var s) ? s : (_state[paymentHash] = new InvoicePollState());
+
+                        // F1/F3: skip while backing off (after errors) or within this invoice's
+                        // age-stepped minimum interval.
+                        if (now < st.NextAttempt)
                             continue;
 
+                        // A settled/expired invoice observed via a prior poll is pruned below; here we
+                        // only prune on pure time-based expiry without needing a verify response.
                         try
                         {
-                            var invoice = await _client.GetInvoice(paymentHash, cancellation);
-                            _backoff.Remove(paymentHash); // success resets back-off
-                            if (invoice is null) continue;
-                            if (invoice.Status == LightningInvoiceStatus.Paid)
+                            var (outcome, invoice) = await _client.PollVerify(paymentHash, cancellation);
+                            switch (outcome)
                             {
-                                RemoveTracked(paymentHash);
-                                await _channel.Writer.WriteAsync(invoice, cancellation);
-                            }
-                            else if (invoice.Status == LightningInvoiceStatus.Expired ||
-                                     tracked.ExpiresAt < DateTimeOffset.UtcNow)
-                            {
-                                RemoveTracked(paymentHash);
+                                case VerifyOutcome.TransportError:
+                                {
+                                    // F1: a real failure => back off (was previously swallowed as success).
+                                    st.NotFounds = 0;
+                                    var (errors, delay) = NextBackoff(st.Errors, PollInterval, MaxBackoff);
+                                    st.Errors = errors;
+                                    st.NextAttempt = DateTimeOffset.UtcNow.Add(delay);
+                                    break;
+                                }
+                                case VerifyOutcome.NotFound:
+                                {
+                                    // F2: evict after consecutive not-founds instead of polling forever.
+                                    st.Errors = 0;
+                                    st.NotFounds++;
+                                    if (st.NotFounds >= NotFoundEvictionThreshold)
+                                    {
+                                        RemoveTracked(paymentHash);
+                                        break;
+                                    }
+                                    // Not a transport error, but slow down re-checks of a missing invoice.
+                                    st.NextAttempt = DateTimeOffset.UtcNow.Add(MaxBackoff);
+                                    break;
+                                }
+                                case VerifyOutcome.Status:
+                                {
+                                    // Success: clear failure state and apply the age-stepped steady-state interval (F3).
+                                    st.Errors = 0;
+                                    st.NotFounds = 0;
+                                    var age = DateTimeOffset.UtcNow - tracked.CreatedAt;
+                                    var intervalMs = ApplyJitter(MinIntervalForAge(age).TotalMilliseconds);
+                                    st.NextAttempt = DateTimeOffset.UtcNow.Add(TimeSpan.FromMilliseconds(intervalMs));
+
+                                    if (invoice is null)
+                                        break;
+                                    if (invoice.Status == LightningInvoiceStatus.Paid)
+                                    {
+                                        RemoveTracked(paymentHash);
+                                        Settled?.Invoke(invoice);
+                                    }
+                                    else if (invoice.Status == LightningInvoiceStatus.Expired ||
+                                             tracked.ExpiresAt < DateTimeOffset.UtcNow)
+                                    {
+                                        RemoveTracked(paymentHash);
+                                    }
+                                    break;
+                                }
                             }
                         }
                         catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
@@ -516,14 +681,22 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
                         }
                         catch (Exception e)
                         {
-                            // Capped exponential back-off so a degraded blink-lnurl-server is not
-                            // hammered every 3s per invoice.
-                            var prevErrors = _backoff.TryGetValue(paymentHash, out var prev) ? prev.Errors : 0;
-                            var (errors, delay) = NextBackoff(prevErrors, PollInterval, MaxBackoff);
-                            _backoff[paymentHash] = (errors, DateTimeOffset.UtcNow.Add(delay));
+                            // Defensive back-off for any unexpected throw escaping PollVerify.
+                            var (errors, delay) = NextBackoff(st.Errors, PollInterval, MaxBackoff);
+                            st.Errors = errors;
+                            st.NextAttempt = DateTimeOffset.UtcNow.Add(delay);
                             _logger.LogDebug(e, "Error polling Blink invoice {PaymentHash} (attempt {Errors}); backing off {DelayMs}ms",
                                 paymentHash, errors, delay.TotalMilliseconds);
                         }
+                    }
+
+                    // Prune poll state for invoices no longer tracked so _state stays bounded.
+                    if (_state.Count > 0)
+                    {
+                        var live = new HashSet<string>(_client._tracked.Keys);
+                        foreach (var key in _state.Keys.ToArray())
+                            if (!live.Contains(key))
+                                _state.Remove(key);
                     }
 
                     await Task.Delay(PollInterval, cancellation);
@@ -534,14 +707,33 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
             }
             catch (Exception e)
             {
-                _channel.Writer.TryComplete(e);
+                _logger.LogDebug(e, "Blink shared verify poll loop for {Address} terminated unexpectedly", _address);
             }
         }
 
         private void RemoveTracked(string paymentHash)
         {
             _client.RemoveTrackedInvoice(paymentHash);
-            _backoff.Remove(paymentHash);
+            _state.Remove(paymentHash);
+        }
+    }
+
+    /// <summary>
+    /// A cheap per-Listen() subscriber over the shared poller's settlement broadcast. It holds no poll
+    /// loop of its own — the single SharedVerifyPoller per address does the polling and fans out.
+    /// </summary>
+    public sealed class BlinkLnAddressListener : ILightningInvoiceListener
+    {
+        private readonly SharedVerifyPoller _poller;
+        private readonly Channel<LightningInvoice> _channel = Channel.CreateUnbounded<LightningInvoice>();
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Action<LightningInvoice> _handler;
+
+        public BlinkLnAddressListener(SharedVerifyPoller poller)
+        {
+            _poller = poller;
+            _handler = inv => _channel.Writer.TryWrite(inv);
+            _poller.Settled += _handler;
         }
 
         public async Task<LightningInvoice> WaitInvoice(CancellationToken cancellation)
@@ -552,13 +744,11 @@ public class BlinkLnAddressLightningClient : IExtendedLightningClient
 
         public void Dispose()
         {
+            _poller.Settled -= _handler;
             _cts.Cancel();
-            // Wait (bounded) for the poll loop to observe cancellation before completing the channel,
-            // so an in-flight WriteAsync cannot race TryComplete and surface a ChannelClosedException.
-            try { _pollTask.Wait(TimeSpan.FromSeconds(5)); }
-            catch { /* AggregateException from cancellation or timeout: ignore on dispose */ }
             _channel.Writer.TryComplete();
             _cts.Dispose();
+            _poller.Release();
         }
     }
 


### PR DESCRIPTION
## Summary
The Blink non-custodial (Spark) receive path polls each tracked invoice's LUD-21 `verify` URL to detect settlement. Two bugs turned this into **runaway polling** of `lnurl.blink.sv/verify/*`.

I built a harness around the real `BlinkLnAddressLightningClient` and measured **~28,800 verify requests/day per stuck/unpaid invoice**, so a few hundred concurrent invoices on a single BTCPay instance reproduce the observed millions/day. `Listen()` fan-out multiplied it further (an exact 3× with 3 listeners).

## Root causes → fixes
- **F1 — backoff was bypassed on real failures.** HTTP 500 / timeout / bad-body were swallowed in `GetInvoice` and returned as a synthetic *Unpaid* invoice, which the poll loop treated as success and **reset** backoff. A degraded server was polled every 3s. Fix: `PollVerify` reports a `VerifyOutcome`, and the loop applies capped exponential backoff on `TransportError`.
- **F2 — `status:ERROR` invoices were never evicted.** A not-found returned null and the removal path was gated behind a non-null invoice → polled forever. Fix: evict after 3 consecutive not-founds (tolerates the create→verify visibility race).
- **F3 — healthy unpaid invoices polled every 3s for their whole expiry.** Fix: age-stepped minimum interval (3s < 2 min, 10s < 10 min, else 30s) — fast right after creation, relaxed for long-lived invoices.
- **F4 — every `Listen()` spawned its own poll loop** over the shared static registry, multiplying request rate by the number of listeners. Fix: a single ref-counted `SharedVerifyPoller` per lightning address; listeners are cheap subscribers to a settlement broadcast (the same shape as the LNURLVerify plugin).
- **F5 — no jitter.** Added ±20% jitter to backoff to avoid lockstep retries.
- **User-Agent** — set `BTCPayServer.Plugins.Blink/<version>` so operators can attribute plugin verify traffic in server telemetry.

## Behavior (harness, 100 invoices unless noted)
| verify response | before | after |
| --- | --- | --- |
| HTTP 500 | full 3s rate, no backoff | backoff engages (≈2 req / 20s / invoice) |
| `status:ERROR` | polled forever | evicted after 3 confirmations, polling stops |
| healthy unpaid | every 3s for whole expiry | age-stepped (3s→10s→30s) |
| 3× `Listen()` | 3× request rate | 1 shared poller |

## Tests
`BlinkLnAddressLogicTests` updated for jitter and extended with `ApplyJitter`, `MinIntervalForAge`, and `UserAgent` cases. **All 55 pass** (`dotnet test --filter BlinkLnAddressLogicTests`).

## Notes
- This is a client-side fix; a complementary server-side path-scoped rate limit on `/verify/*` is being rolled out separately.
- The generic **LNURLVerify** plugin shares the same F1/F2/F3/F5 pattern (it already has the shared-poller design, so it doesn't need F4). Happy to port these fixes there too in a follow-up if you'd like — glad to consolidate.
- The durable fix is to eliminate polling entirely (server-pushed settlement / a LUD-21 bounded-poll amendment); noting it here as a longer-term direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved Lightning invoice verification with adaptive polling intervals and jittered backoff.
  - Better handling of temporary connection issues and missing invoices, reducing premature tracking removal.
  - Consolidated monitoring for multiple listeners on the same Lightning address to improve efficiency.
  - Added clearer service identification when communicating with Blink.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->