### PR TITLE
Blink: warn that a stored custodial API key is readable by the server operator

### DIFF
--- a/Plugins/BTCPayServer.Plugins.Blink/README.md
+++ b/Plugins/BTCPayServer.Plugins.Blink/README.md
@@ -23,6 +23,14 @@ type=blink;server=https://api.blink.sv/graphql;api-key=blink_...;wallet-id=xyz;c
 Create an API key on the [Blink dashboard](https://dashboard.blink.sv). For BTCPay receiving you
 need at least the `READ` and `RECEIVE` scopes; `WRITE` is additionally required to pay invoices.
 
+> **The API key is stored on this server, and its operator can read it.** BTCPay keeps the key in the
+> store's Lightning settings, so whoever operates the server can read it and use it for whatever the key
+> is scoped to — a `WRITE` key can spend the account's balance. Grant only the scopes BTCPay needs
+> (`READ` + `RECEIVE` to receive; add `WRITE` only if BTCPay must also pay invoices), and if you do not
+> operate and trust this server, treat the key as exposed to its operator. A key can be revoked and
+> replaced from the Blink dashboard at any time. The non-custodial `ln-address=` path below stores no
+> credential and is not affected.
+
 ### Non-custodial (Spark) account — receive only
 
 The new Blink non-custodial accounts do not expose an API key or a GraphQL wallet id. Receiving is

--- a/Plugins/BTCPayServer.Plugins.Blink/Views/Shared/Blink/LNPaymentMethodSetupTab.cshtml
+++ b/Plugins/BTCPayServer.Plugins.Blink/Views/Shared/Blink/LNPaymentMethodSetupTab.cshtml
@@ -34,6 +34,15 @@
                     </li>
                 </ul>
                 <p class="my-2">Head over to the <a href="https://dashboard.blink.sv" target="_blank" rel="noreferrer noopener" >Blink dashboard</a> and create an api key. The server is optional and will use the default Blink instance.The wallet-id is optional and will use the default wallet otherwise.</p>
+                <div class="alert alert-warning my-2" role="alert">
+                    <strong>The API key is stored on this server.</strong> BTCPay keeps it in the store's
+                    Lightning settings, so whoever operates the server can read it and use it for whatever the
+                    key is scoped to — a <code>WRITE</code> key can spend the account's balance. Grant the key
+                    only the scopes BTCPay needs: <code>READ</code> and <code>RECEIVE</code> to receive
+                    payments, and <code>WRITE</code> only if BTCPay must also pay invoices. If you do not
+                    operate and trust this server, treat the key as exposed to its operator; a key can be
+                    revoked and replaced from the Blink dashboard at any time.
+                </div>
                 <p class="my-2"><strong>Non-custodial (Spark) account</strong> — receive only, no API key:</p>
                 <ul class="pb-2">
                     <li>


### PR DESCRIPTION
## What

Adds a server-trust warning to the **custodial (API key)** path in the Blink plugin — on the setup tab and in the README — stating that BTCPay stores the API key in the store's Lightning settings, so whoever operates the server can read it and use it for whatever the key is scoped to (a `WRITE` key can spend the account's balance).

The warning is deliberately proportionate. A user consciously selects the key's scopes in the Blink dashboard, so this is not "you didn't know what the key does" — it is a reminder of the *server-storage* consequence, which is the part that isn't visible at key-creation time: on a shared or public-registration BTCPay instance the key sits on a host the tenant may not operate. It leads with the two mitigations that actually apply here:

- **Minimize scope** — `READ` + `RECEIVE` to receive; add `WRITE` only if BTCPay must also pay invoices. A leaked receive-only key cannot spend.
- **Revoke** — a key can be rotated/revoked from the dashboard at any time.

The non-custodial `ln-address=` path stores no credential and is explicitly noted as unaffected.

## Why

BTCPay's Flint (Spark) plugin recently added an equivalent disclosure for the same class of exposure — a server-stored spend credential readable by the instance admin — in sethforprivacy/flint#45 (raised in sethforprivacy/flint#43). This applies the same fiduciary principle to Blink's custodial path. The exposure is genuinely *less* critical here than in the seed case, because a Blink API key is scope-limitable and revocable where a wallet seed is neither, and the warning says so rather than overstating it.

## Changes

- `Views/Shared/Blink/LNPaymentMethodSetupTab.cshtml` — warning alert after the API-key setup instructions.
- `README.md` — matching note under the custodial account section.

Docs/UI copy only; no behavioural change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security guidance for custodial Blink API keys, including storage visibility and server operator access.
  * Clarified scope permissions, including the spending capability of `WRITE` keys.
  * Recommended limiting key scopes and revoking keys when no longer needed.
  * Documented the credential-free non-custodial setup option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->